### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: drud


### PR DESCRIPTION
Adding sponsorship button to DDEV APIs repo on GitHub

**The Problem/Issue/Bug:**
It is now possible to sponsor DDEV as an organization on GitHub. However the "sponsor" button is only available on the parent organization page.

**How this PR Solves The Problem:**
This PR creates a FUNDING.yml file to display a GitHub sponsorship button on the DDEV APIs repository.

**Related:**
https://github.com/drud/ddev/pull/2479