### PR TITLE
API for site cloning

### DIFF
--- a/doc/api/administration-api.md
+++ b/doc/api/administration-api.md
@@ -3,6 +3,9 @@
 
 ## Table of Contents
 
+- [live/administration/v1alpha1/service.proto](#live/administration/v1alpha1/service.proto)
+    - [Administration](#ddev.administration.v1alpha1.Administration)
+  
 - [live/administration/v1alpha1/auth.proto](#live/administration/v1alpha1/auth.proto)
     - [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest)
     - [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse)
@@ -25,9 +28,6 @@
   
     - [Capability](#ddev.administration.v1alpha1.Capability)
   
-- [live/administration/v1alpha1/service.proto](#live/administration/v1alpha1/service.proto)
-    - [Administration](#ddev.administration.v1alpha1.Administration)
-  
 - [live/administration/v1alpha1/workspace.proto](#live/administration/v1alpha1/workspace.proto)
     - [AddWorkspaceAdminRequest](#ddev.administration.v1alpha1.AddWorkspaceAdminRequest)
     - [AddWorkspaceAdminResponse](#ddev.administration.v1alpha1.AddWorkspaceAdminResponse)
@@ -44,6 +44,63 @@
     - [ListWorkspaceRequest.ListWorkspaceScope](#ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope)
   
 - [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="live/administration/v1alpha1/service.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## live/administration/v1alpha1/service.proto
+
+
+ 
+
+ 
+
+ 
+
+
+<a name="ddev.administration.v1alpha1.Administration"></a>
+
+### Administration
+The Billing service provides administrative functions over a users ddev-live account.
+To access the billing service consumers will have to initialize an authenticated client.  This requires
+several metadata to be passed to the client.
+
+`x-auth-token` which is a authentication token for the call.  In most cases this will be a temporary token 
+issued by the API.  This can be the integration token provided on the dashboard when retrieving temporary tokens.
+
+`x-ddev-workspace` which is the workspace for all workspace scoped procedures.  For example a client request `ListSubscriptions` will list all subscriptions in the workspace whose value is derived from the key `x-ddev-workspace`.
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| CreateToken | [CreateTokenRequest](#ddev.administration.v1alpha1.CreateTokenRequest) | [CreateTokenResponse](#ddev.administration.v1alpha1.CreateTokenResponse) | Creates an ID token from a refresh token |
+| CreateRoles | [CreateRoleRequest](#ddev.administration.v1alpha1.CreateRoleRequest) | [CreateRoleResponse](#ddev.administration.v1alpha1.CreateRoleResponse) | Creates a Role |
+| DescribeRole | [DescribeRoleRequest](#ddev.administration.v1alpha1.DescribeRoleRequest) | [DescribeRoleResponse](#ddev.administration.v1alpha1.DescribeRoleResponse) | Describes a named role |
+| ListRoles | [ListRolesRequest](#ddev.administration.v1alpha1.ListRolesRequest) | [ListRolesResponse](#ddev.administration.v1alpha1.ListRolesResponse) | Lists all known roles |
+| SetCapabilities | [SetCapabilitiesRequest](#ddev.administration.v1alpha1.SetCapabilitiesRequest) | [SetCapabilitiesResponse](#ddev.administration.v1alpha1.SetCapabilitiesResponse) | Updates a users API capabilities. Will requre a refresh of their token through CreateToken. |
+| ListCapabilities | [ListCapabilitiesRequest](#ddev.administration.v1alpha1.ListCapabilitiesRequest) | [ListCapabilitiesResponse](#ddev.administration.v1alpha1.ListCapabilitiesResponse) | Lists a users API capabilities. |
+| ListWorkspaces | [ListWorkspaceRequest](#ddev.administration.v1alpha1.ListWorkspaceRequest) | [ListWorkspaceResponse](#ddev.administration.v1alpha1.ListWorkspaceResponse) | ListWorkspaces will return a list of workspaces the user has authorization for |
+| AddWorkspaceAdmin | [AddWorkspaceAdminRequest](#ddev.administration.v1alpha1.AddWorkspaceAdminRequest) | [AddWorkspaceAdminResponse](#ddev.administration.v1alpha1.AddWorkspaceAdminResponse) | Add an administrator to a workspace. Requires a workspace administrator token. |
+| AddWorkspaceDeveloper | [AddWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest) | [AddWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse) | Add a developer to a workspace. Requires a workspace administrator token. |
+| DeleteWorkspaceAdmin | [DeleteWorkspaceAdminRequest](#ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest) | [DeleteWorkspaceAdminResponse](#ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse) | Remove an administrator from a workspace. Requires a workspace administrator token. An administrator cannot remove themselves. |
+| DeleteWorkspaceDeveloper | [DeleteWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest) | [DeleteWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse) | Remove a developer from a workspace. Requires a workspace administrator token. |
+| IsAuthTokenViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can read the API scopes a user has. |
+| IsAuthTokenEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can issue different API access scopes within an organization |
+| IsBillingViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can access billing artifacts such as invoices |
+| IsBillingEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can modify elements such as their subscription |
+| IsWorkspaceAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is an admin of a workspace |
+| IsWorkspaceViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which has read capability for workspace objects |
+| IsSiteEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is capable of creating or modifying a site |
+| IsSiteViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is capable of viewing site specifications created in a workspace |
+| IsLogsViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows for the viewing of site logs |
+| IsSiteExecutor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows for the execution of commands inside a running site container |
+| IsDatabaseAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows full control over site databases, which includes restore and push operations |
+| IsDatabaseViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows pull access for a sites database |
+| IsFileAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows full control over site files, which includes restore and push operations |
+| IsFileViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows pull access for a sites files |
+
+ 
 
 
 
@@ -354,63 +411,6 @@ Describes a set of access policies for a user
  
 
  
-
- 
-
-
-
-<a name="live/administration/v1alpha1/service.proto"></a>
-<p align="right"><a href="#top">Top</a></p>
-
-## live/administration/v1alpha1/service.proto
-
-
- 
-
- 
-
- 
-
-
-<a name="ddev.administration.v1alpha1.Administration"></a>
-
-### Administration
-The Billing service provides administrative functions over a users ddev-live account.
-To access the billing service consumers will have to initialize an authenticated client.  This requires
-several metadata to be passed to the client.
-
-`x-auth-token` which is a authentication token for the call.  In most cases this will be a temporary token 
-issued by the API.  This can be the integration token provided on the dashboard when retrieving temporary tokens.
-
-`x-ddev-workspace` which is the workspace for all workspace scoped procedures.  For example a client request `ListSubscriptions` will list all subscriptions in the workspace whose value is derived from the key `x-ddev-workspace`.
-
-| Method Name | Request Type | Response Type | Description |
-| ----------- | ------------ | ------------- | ------------|
-| CreateToken | [CreateTokenRequest](#ddev.administration.v1alpha1.CreateTokenRequest) | [CreateTokenResponse](#ddev.administration.v1alpha1.CreateTokenResponse) | Creates an ID token from a refresh token |
-| CreateRoles | [CreateRoleRequest](#ddev.administration.v1alpha1.CreateRoleRequest) | [CreateRoleResponse](#ddev.administration.v1alpha1.CreateRoleResponse) | Creates a Role |
-| DescribeRole | [DescribeRoleRequest](#ddev.administration.v1alpha1.DescribeRoleRequest) | [DescribeRoleResponse](#ddev.administration.v1alpha1.DescribeRoleResponse) | Describes a named role |
-| ListRoles | [ListRolesRequest](#ddev.administration.v1alpha1.ListRolesRequest) | [ListRolesResponse](#ddev.administration.v1alpha1.ListRolesResponse) | Lists all known roles |
-| SetCapabilities | [SetCapabilitiesRequest](#ddev.administration.v1alpha1.SetCapabilitiesRequest) | [SetCapabilitiesResponse](#ddev.administration.v1alpha1.SetCapabilitiesResponse) | Updates a users API capabilities. Will requre a refresh of their token through CreateToken. |
-| ListCapabilities | [ListCapabilitiesRequest](#ddev.administration.v1alpha1.ListCapabilitiesRequest) | [ListCapabilitiesResponse](#ddev.administration.v1alpha1.ListCapabilitiesResponse) | Lists a users API capabilities. |
-| ListWorkspaces | [ListWorkspaceRequest](#ddev.administration.v1alpha1.ListWorkspaceRequest) | [ListWorkspaceResponse](#ddev.administration.v1alpha1.ListWorkspaceResponse) | ListWorkspaces will return a list of workspaces the user has authorization for |
-| AddWorkspaceAdmin | [AddWorkspaceAdminRequest](#ddev.administration.v1alpha1.AddWorkspaceAdminRequest) | [AddWorkspaceAdminResponse](#ddev.administration.v1alpha1.AddWorkspaceAdminResponse) | Add an administrator to a workspace. Requires a workspace administrator token. |
-| AddWorkspaceDeveloper | [AddWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest) | [AddWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse) | Add a developer to a workspace. Requires a workspace administrator token. |
-| DeleteWorkspaceAdmin | [DeleteWorkspaceAdminRequest](#ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest) | [DeleteWorkspaceAdminResponse](#ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse) | Remove an administrator from a workspace. Requires a workspace administrator token. An administrator cannot remove themselves. |
-| DeleteWorkspaceDeveloper | [DeleteWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest) | [DeleteWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse) | Remove a developer from a workspace. Requires a workspace administrator token. |
-| IsAuthTokenViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can read the API scopes a user has. |
-| IsAuthTokenEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can issue different API access scopes within an organization |
-| IsBillingViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can access billing artifacts such as invoices |
-| IsBillingEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can modify elements such as their subscription |
-| IsWorkspaceAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is an admin of a workspace |
-| IsWorkspaceViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which has read capability for workspace objects |
-| IsSiteEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is capable of creating or modifying a site |
-| IsSiteViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is capable of viewing site specifications created in a workspace |
-| IsLogsViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows for the viewing of site logs |
-| IsSiteExecutor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows for the execution of commands inside a running site container |
-| IsDatabaseAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows full control over site databases, which includes restore and push operations |
-| IsDatabaseViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows pull access for a sites database |
-| IsFileAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows full control over site files, which includes restore and push operations |
-| IsFileViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows pull access for a sites files |
 
  
 

--- a/doc/api/site-api.md
+++ b/doc/api/site-api.md
@@ -3,6 +3,9 @@
 
 ## Table of Contents
 
+- [live/sites/v1alpha1/service.proto](#live/sites/v1alpha1/service.proto)
+    - [Sites](#ddev.sites.v1alpha1.Sites)
+  
 - [live/sites/v1alpha1/file.proto](#live/sites/v1alpha1/file.proto)
     - [BackupFilesRequest](#ddev.sites.v1alpha1.BackupFilesRequest)
     - [BackupFilesResponse](#ddev.sites.v1alpha1.BackupFilesResponse)
@@ -19,9 +22,6 @@
     - [PushFileBackupResponse](#ddev.sites.v1alpha1.PushFileBackupResponse)
     - [RestoreFilesRequest](#ddev.sites.v1alpha1.RestoreFilesRequest)
     - [RestoreFilesResponse](#ddev.sites.v1alpha1.RestoreFilesResponse)
-  
-- [live/sites/v1alpha1/service.proto](#live/sites/v1alpha1/service.proto)
-    - [Sites](#ddev.sites.v1alpha1.Sites)
   
 - [live/sites/v1alpha1/database.proto](#live/sites/v1alpha1/database.proto)
     - [BackupDatabaseRequest](#ddev.sites.v1alpha1.BackupDatabaseRequest)
@@ -42,6 +42,9 @@
 - [live/sites/v1alpha1/site.proto](#live/sites/v1alpha1/site.proto)
     - [AccessLogsRequest](#ddev.sites.v1alpha1.AccessLogsRequest)
     - [AccessLogsResponse](#ddev.sites.v1alpha1.AccessLogsResponse)
+    - [CloneOperation](#ddev.sites.v1alpha1.CloneOperation)
+    - [CloneRequest](#ddev.sites.v1alpha1.CloneRequest)
+    - [CloneResponse](#ddev.sites.v1alpha1.CloneResponse)
     - [CreateSiteRequest](#ddev.sites.v1alpha1.CreateSiteRequest)
     - [CreateSiteResponse](#ddev.sites.v1alpha1.CreateSiteResponse)
     - [Cron](#ddev.sites.v1alpha1.Cron)
@@ -52,6 +55,10 @@
     - [GetSiteRequest](#ddev.sites.v1alpha1.GetSiteRequest)
     - [GetSiteResponse](#ddev.sites.v1alpha1.GetSiteResponse)
     - [GitRepository](#ddev.sites.v1alpha1.GitRepository)
+    - [ListCloneSiteOperationsRequest](#ddev.sites.v1alpha1.ListCloneSiteOperationsRequest)
+    - [ListCloneSiteOperationsResponse](#ddev.sites.v1alpha1.ListCloneSiteOperationsResponse)
+    - [ListClonesForSiteRequest](#ddev.sites.v1alpha1.ListClonesForSiteRequest)
+    - [ListClonesForSiteResponse](#ddev.sites.v1alpha1.ListClonesForSiteResponse)
     - [ListSiteRequest](#ddev.sites.v1alpha1.ListSiteRequest)
     - [ListSiteResponse](#ddev.sites.v1alpha1.ListSiteResponse)
     - [LogOptions](#ddev.sites.v1alpha1.LogOptions)
@@ -69,9 +76,67 @@
     - [WordpressSite](#ddev.sites.v1alpha1.WordpressSite)
     - [WordpressSiteOptions](#ddev.sites.v1alpha1.WordpressSiteOptions)
   
+    - [CloneOperationState](#ddev.sites.v1alpha1.CloneOperationState)
     - [SiteType](#ddev.sites.v1alpha1.SiteType)
   
 - [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="live/sites/v1alpha1/service.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## live/sites/v1alpha1/service.proto
+
+
+ 
+
+ 
+
+ 
+
+
+<a name="ddev.sites.v1alpha1.Sites"></a>
+
+### Sites
+The Sites service provides site level functions inside a users ddev-live workspace.
+To access the sites service consumers will have to initialize an authenticated client.  This requires
+several metadata to be passed to the client.
+
+`x-auth-token` which is a authentication token for the call.  This will be required to be a temporary token issued by the BillingAPI.
+
+`x-ddev-workspace` which is the workspace for all procedures.  For example a client request `ListSites` will list all sites in the workspace whose value is derived from the key `x-ddev-workspace`.
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| CreateSite | [CreateSiteRequest](#ddev.sites.v1alpha1.CreateSiteRequest) | [CreateSiteResponse](#ddev.sites.v1alpha1.CreateSiteResponse) | CreateSite creates one of the supported site types |
+| GetSite | [GetSiteRequest](#ddev.sites.v1alpha1.GetSiteRequest) | [GetSiteResponse](#ddev.sites.v1alpha1.GetSiteResponse) | GetSite returns the state of a site by name |
+| ListSites | [ListSiteRequest](#ddev.sites.v1alpha1.ListSiteRequest) | [ListSiteResponse](#ddev.sites.v1alpha1.ListSiteResponse) | ListSites returns all sites within a workspace |
+| UpdateSite | [UpdateSiteRequest](#ddev.sites.v1alpha1.UpdateSiteRequest) | [UpdateSiteResponse](#ddev.sites.v1alpha1.UpdateSiteResponse) |  |
+| DeleteSite | [DeleteSiteRequest](#ddev.sites.v1alpha1.DeleteSiteRequest) | [DeleteSiteResponse](#ddev.sites.v1alpha1.DeleteSiteResponse) |  |
+| SiteLogStream | [SiteLogsRequest](#ddev.sites.v1alpha1.SiteLogsRequest) | [SiteLogsResponse](#ddev.sites.v1alpha1.SiteLogsResponse) stream | SiteLogStream returns a stream of logs for a site |
+| AccessLogStream | [AccessLogsRequest](#ddev.sites.v1alpha1.AccessLogsRequest) | [AccessLogsResponse](#ddev.sites.v1alpha1.AccessLogsResponse) stream | AccessLogStream returns a stream of access logs for a site |
+| MysqlLogStream | [MysqlLogsRequest](#ddev.sites.v1alpha1.MysqlLogsRequest) | [MysqlLogsResponse](#ddev.sites.v1alpha1.MysqlLogsResponse) stream | MysqlLogStream returns a stream of access logs for a site |
+| SiteExecStream | [SiteExecRequest](#ddev.sites.v1alpha1.SiteExecRequest) stream | [SiteExecResponse](#ddev.sites.v1alpha1.SiteExecResponse) stream | SiteExecStream allows for the streaming execution of commands inside a site container |
+| CloneSite | [CloneRequest](#ddev.sites.v1alpha1.CloneRequest) | [CloneResponse](#ddev.sites.v1alpha1.CloneResponse) | CloneSite creates a clone of already existing site |
+| ListCloneSiteOperations | [ListCloneSiteOperationsRequest](#ddev.sites.v1alpha1.ListCloneSiteOperationsRequest) | [ListCloneSiteOperationsResponse](#ddev.sites.v1alpha1.ListCloneSiteOperationsResponse) | ListCloneSiteOperations lists all clone site operations |
+| ListClonesForSite | [ListClonesForSiteRequest](#ddev.sites.v1alpha1.ListClonesForSiteRequest) | [ListClonesForSiteResponse](#ddev.sites.v1alpha1.ListClonesForSiteResponse) | ListClonesForSite lists all clones for a particular origin site |
+| BackupDatabase | [BackupDatabaseRequest](#ddev.sites.v1alpha1.BackupDatabaseRequest) | [BackupDatabaseResponse](#ddev.sites.v1alpha1.BackupDatabaseResponse) | BackupDatabase backs up a database associated with a site |
+| RestoreDatabase | [RestoreDatabaseRequest](#ddev.sites.v1alpha1.RestoreDatabaseRequest) | [RestoreDatabaseResponse](#ddev.sites.v1alpha1.RestoreDatabaseResponse) | RestoreDatabase restores a sites databases to a known backup |
+| PushDatabaseBackup | [PushDatabaseBackupRequest](#ddev.sites.v1alpha1.PushDatabaseBackupRequest) | [PushDatabaseBackupResponse](#ddev.sites.v1alpha1.PushDatabaseBackupResponse) | PushDatabaseBackup creates a new backup for a site and attempts to restore the site to that backup |
+| PushDatabaseBackupStream | [PushDatabaseBackupRequest](#ddev.sites.v1alpha1.PushDatabaseBackupRequest) stream | [PushDatabaseBackupResponse](#ddev.sites.v1alpha1.PushDatabaseBackupResponse) | PushDatabaseBackupStream creates a new backup for a site and attempts to restore the site to that backup |
+| PullDatabaseBackup | [PullDatabaseBackupRequest](#ddev.sites.v1alpha1.PullDatabaseBackupRequest) | [PullDatabaseBackupResponse](#ddev.sites.v1alpha1.PullDatabaseBackupResponse) | PullDatabase pulls down a database backup locally |
+| PullDatabaseBackupStream | [PullDatabaseBackupRequest](#ddev.sites.v1alpha1.PullDatabaseBackupRequest) | [PullDatabaseBackupResponse](#ddev.sites.v1alpha1.PullDatabaseBackupResponse) stream | PullDatabaseBackupStream pulls down a database backup locally |
+| ListDatabaseBackups | [ListDatabaseBackupsRequest](#ddev.sites.v1alpha1.ListDatabaseBackupsRequest) | [ListDatabaseBackupsResponse](#ddev.sites.v1alpha1.ListDatabaseBackupsResponse) | Lists database backups known for a provided site |
+| BackupFiles | [BackupFilesRequest](#ddev.sites.v1alpha1.BackupFilesRequest) | [BackupFilesResponse](#ddev.sites.v1alpha1.BackupFilesResponse) | BackupFiles backups up a currently running site environment to the staging area |
+| RestoreFiles | [RestoreFilesRequest](#ddev.sites.v1alpha1.RestoreFilesRequest) | [RestoreFilesResponse](#ddev.sites.v1alpha1.RestoreFilesResponse) | RestoreFiles restores the current staging area to a sites environment |
+| PushFileBackup | [PushFileBackupRequest](#ddev.sites.v1alpha1.PushFileBackupRequest) | [PushFileBackupResponse](#ddev.sites.v1alpha1.PushFileBackupResponse) | PushFile upload file assets to a sites backup staging area |
+| PushFileBackupStream | [PushFileBackupRequest](#ddev.sites.v1alpha1.PushFileBackupRequest) stream | [PushFileBackupResponse](#ddev.sites.v1alpha1.PushFileBackupResponse) | PushFileStream allows client side streaming of large files to a staged backup area |
+| PullFileBackupStream | [PullFileBackupRequest](#ddev.sites.v1alpha1.PullFileBackupRequest) | [PullFileBackupResponse](#ddev.sites.v1alpha1.PullFileBackupResponse) stream | PullFileStream streams currently staged file[s] from the server and pulls them down to a local source |
+| DescribeFileBackup | [DescribeFileBackupRequest](#ddev.sites.v1alpha1.DescribeFileBackupRequest) | [DescribeFileBackupResponse](#ddev.sites.v1alpha1.DescribeFileBackupResponse) | DescribeFiles returns the metadata for current files staged for a restore operation |
+| ListFileBackups | [ListFileBackupsRequest](#ddev.sites.v1alpha1.ListFileBackupsRequest) | [ListFileBackupsResponse](#ddev.sites.v1alpha1.ListFileBackupsResponse) | Lists file backups known for a provided site |
+
+ 
 
 
 
@@ -321,60 +386,6 @@ TODO
  
 
  
-
- 
-
-
-
-<a name="live/sites/v1alpha1/service.proto"></a>
-<p align="right"><a href="#top">Top</a></p>
-
-## live/sites/v1alpha1/service.proto
-
-
- 
-
- 
-
- 
-
-
-<a name="ddev.sites.v1alpha1.Sites"></a>
-
-### Sites
-The Sites service provides site level functions inside a users ddev-live workspace.
-To access the sites service consumers will have to initialize an authenticated client.  This requires
-several metadata to be passed to the client.
-
-`x-auth-token` which is a authentication token for the call.  This will be required to be a temporary token issued by the BillingAPI.
-
-`x-ddev-workspace` which is the workspace for all procedures.  For example a client request `ListSites` will list all sites in the workspace whose value is derived from the key `x-ddev-workspace`.
-
-| Method Name | Request Type | Response Type | Description |
-| ----------- | ------------ | ------------- | ------------|
-| CreateSite | [CreateSiteRequest](#ddev.sites.v1alpha1.CreateSiteRequest) | [CreateSiteResponse](#ddev.sites.v1alpha1.CreateSiteResponse) | CreateSite creates one of the supported site types |
-| GetSite | [GetSiteRequest](#ddev.sites.v1alpha1.GetSiteRequest) | [GetSiteResponse](#ddev.sites.v1alpha1.GetSiteResponse) | GetSite returns the state of a site by name |
-| ListSites | [ListSiteRequest](#ddev.sites.v1alpha1.ListSiteRequest) | [ListSiteResponse](#ddev.sites.v1alpha1.ListSiteResponse) | ListSites returns all sites within a workspace |
-| UpdateSite | [UpdateSiteRequest](#ddev.sites.v1alpha1.UpdateSiteRequest) | [UpdateSiteResponse](#ddev.sites.v1alpha1.UpdateSiteResponse) |  |
-| DeleteSite | [DeleteSiteRequest](#ddev.sites.v1alpha1.DeleteSiteRequest) | [DeleteSiteResponse](#ddev.sites.v1alpha1.DeleteSiteResponse) |  |
-| SiteLogStream | [SiteLogsRequest](#ddev.sites.v1alpha1.SiteLogsRequest) | [SiteLogsResponse](#ddev.sites.v1alpha1.SiteLogsResponse) stream | SiteLogStream returns a stream of logs for a site |
-| AccessLogStream | [AccessLogsRequest](#ddev.sites.v1alpha1.AccessLogsRequest) | [AccessLogsResponse](#ddev.sites.v1alpha1.AccessLogsResponse) stream | AccessLogStream returns a stream of access logs for a site |
-| MysqlLogStream | [MysqlLogsRequest](#ddev.sites.v1alpha1.MysqlLogsRequest) | [MysqlLogsResponse](#ddev.sites.v1alpha1.MysqlLogsResponse) stream | MysqlLogStream returns a stream of access logs for a site |
-| SiteExecStream | [SiteExecRequest](#ddev.sites.v1alpha1.SiteExecRequest) stream | [SiteExecResponse](#ddev.sites.v1alpha1.SiteExecResponse) stream | SiteExecStream allows for the streaming execution of commands inside a site container |
-| BackupDatabase | [BackupDatabaseRequest](#ddev.sites.v1alpha1.BackupDatabaseRequest) | [BackupDatabaseResponse](#ddev.sites.v1alpha1.BackupDatabaseResponse) | BackupDatabase backs up a database associated with a site |
-| RestoreDatabase | [RestoreDatabaseRequest](#ddev.sites.v1alpha1.RestoreDatabaseRequest) | [RestoreDatabaseResponse](#ddev.sites.v1alpha1.RestoreDatabaseResponse) | RestoreDatabase restores a sites databases to a known backup |
-| PushDatabaseBackup | [PushDatabaseBackupRequest](#ddev.sites.v1alpha1.PushDatabaseBackupRequest) | [PushDatabaseBackupResponse](#ddev.sites.v1alpha1.PushDatabaseBackupResponse) | PushDatabaseBackup creates a new backup for a site and attempts to restore the site to that backup |
-| PushDatabaseBackupStream | [PushDatabaseBackupRequest](#ddev.sites.v1alpha1.PushDatabaseBackupRequest) stream | [PushDatabaseBackupResponse](#ddev.sites.v1alpha1.PushDatabaseBackupResponse) | PushDatabaseBackupStream creates a new backup for a site and attempts to restore the site to that backup |
-| PullDatabaseBackup | [PullDatabaseBackupRequest](#ddev.sites.v1alpha1.PullDatabaseBackupRequest) | [PullDatabaseBackupResponse](#ddev.sites.v1alpha1.PullDatabaseBackupResponse) | PullDatabase pulls down a database backup locally |
-| PullDatabaseBackupStream | [PullDatabaseBackupRequest](#ddev.sites.v1alpha1.PullDatabaseBackupRequest) | [PullDatabaseBackupResponse](#ddev.sites.v1alpha1.PullDatabaseBackupResponse) stream | PullDatabaseBackupStream pulls down a database backup locally |
-| ListDatabaseBackups | [ListDatabaseBackupsRequest](#ddev.sites.v1alpha1.ListDatabaseBackupsRequest) | [ListDatabaseBackupsResponse](#ddev.sites.v1alpha1.ListDatabaseBackupsResponse) | Lists database backups known for a provided site |
-| BackupFiles | [BackupFilesRequest](#ddev.sites.v1alpha1.BackupFilesRequest) | [BackupFilesResponse](#ddev.sites.v1alpha1.BackupFilesResponse) | BackupFiles backups up a currently running site environment to the staging area |
-| RestoreFiles | [RestoreFilesRequest](#ddev.sites.v1alpha1.RestoreFilesRequest) | [RestoreFilesResponse](#ddev.sites.v1alpha1.RestoreFilesResponse) | RestoreFiles restores the current staging area to a sites environment |
-| PushFileBackup | [PushFileBackupRequest](#ddev.sites.v1alpha1.PushFileBackupRequest) | [PushFileBackupResponse](#ddev.sites.v1alpha1.PushFileBackupResponse) | PushFile upload file assets to a sites backup staging area |
-| PushFileBackupStream | [PushFileBackupRequest](#ddev.sites.v1alpha1.PushFileBackupRequest) stream | [PushFileBackupResponse](#ddev.sites.v1alpha1.PushFileBackupResponse) | PushFileStream allows client side streaming of large files to a staged backup area |
-| PullFileBackupStream | [PullFileBackupRequest](#ddev.sites.v1alpha1.PullFileBackupRequest) | [PullFileBackupResponse](#ddev.sites.v1alpha1.PullFileBackupResponse) stream | PullFileStream streams currently staged file[s] from the server and pulls them down to a local source |
-| DescribeFileBackup | [DescribeFileBackupRequest](#ddev.sites.v1alpha1.DescribeFileBackupRequest) | [DescribeFileBackupResponse](#ddev.sites.v1alpha1.DescribeFileBackupResponse) | DescribeFiles returns the metadata for current files staged for a restore operation |
-| ListFileBackups | [ListFileBackupsRequest](#ddev.sites.v1alpha1.ListFileBackupsRequest) | [ListFileBackupsResponse](#ddev.sites.v1alpha1.ListFileBackupsResponse) | Lists file backups known for a provided site |
 
  
 
@@ -631,6 +642,59 @@ Push a single database to a site
 
 
 
+<a name="ddev.sites.v1alpha1.CloneOperation"></a>
+
+### CloneOperation
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| ref | [string](#string) |  | `OutputOnly` Reference to the clone site operation |
+| originSite | [string](#string) |  | `OutputOnly` Name of the origin site |
+| newSite | [string](#string) |  | `OutputOnly` Name of the new site |
+| state | [CloneOperationState](#ddev.sites.v1alpha1.CloneOperationState) |  | `OutputOnly` State of the clone operation |
+| info | [string](#string) |  | `OutputOnly` Optionally contains additional human readable information describing the state of the operation |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.CloneRequest"></a>
+
+### CloneRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| originSite | [string](#string) |  | `Required` The name of the origin site |
+| newSite | [string](#string) |  | `Required` The name of the new site |
+| git | [GitRepository](#ddev.sites.v1alpha1.GitRepository) |  |  |
+| dbBackup | [string](#string) |  | `Optional` Override to use a db backup instead of the origin&#39;s site database |
+| fsBackup | [string](#string) |  | `Optional` Override to the a filestore backup instead of the origin&#39;s site filestore |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.CloneResponse"></a>
+
+### CloneResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| operationRef | [string](#string) |  | `OutputOnly` Reference to the clone site operation |
+
+
+
+
+
+
 <a name="ddev.sites.v1alpha1.CreateSiteRequest"></a>
 
 ### CreateSiteRequest
@@ -790,8 +854,63 @@ A site of SiteType.DRUPAL
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| url | [string](#string) |  | `Required` The URL of the repository |
-| ref | [string](#string) |  | `Required` The branch, tag, or commit. Default: `master`. |
+| url | [string](#string) |  | The URL of the repository |
+| ref | [string](#string) |  | The branch, tag, or commit. Default: `master`. |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.ListCloneSiteOperationsRequest"></a>
+
+### ListCloneSiteOperationsRequest
+
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.ListCloneSiteOperationsResponse"></a>
+
+### ListCloneSiteOperationsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| items | [CloneOperation](#ddev.sites.v1alpha1.CloneOperation) | repeated | `OutputOnly` List of clone site operations |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.ListClonesForSiteRequest"></a>
+
+### ListClonesForSiteRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| originSite | [string](#string) |  | `Required` List all clones for a particular origin site |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.ListClonesForSiteResponse"></a>
+
+### ListClonesForSiteResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| clones | [Site](#ddev.sites.v1alpha1.Site) | repeated | `OutputOnly` List all clones for a particular origin site |
 
 
 
@@ -1056,6 +1175,19 @@ A site of SiteType.WORDPRESS
 
 
  
+
+
+<a name="ddev.sites.v1alpha1.CloneOperationState"></a>
+
+### CloneOperationState
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| CLONE_CREATED | 0 |  |
+| CLONE_SUCCEEDED | 1 |  |
+| CLONE_FAILED | 2 |  |
+
 
 
 <a name="ddev.sites.v1alpha1.SiteType"></a>

--- a/live/sites/v1alpha1/service.proto
+++ b/live/sites/v1alpha1/service.proto
@@ -94,6 +94,26 @@ service Sites {
 
     }
 
+    // Site Clones
+
+    /*
+    CloneSite creates a clone of already existing site 
+    */
+    rpc CloneSite(CloneSiteRequest) returns (CloneSiteResponse) {
+    }
+    
+    /*
+    ListCloneSiteOperations lists all currently pending clone site operations
+    */
+    rpc ListCloneSiteOperations(ListCloneSiteOperationsRequest) returns (ListCloneSiteOperationsResponse) {
+    }
+    
+    /*
+    ListSiteClones lists all clones for a particular origin site
+    */
+    rpc ListSiteClones(ListSiteClonesRequest) returns (ListSiteClonesResponse) {
+    }
+
     // Databases
 
     /*

--- a/live/sites/v1alpha1/service.proto
+++ b/live/sites/v1alpha1/service.proto
@@ -103,15 +103,15 @@ service Sites {
     }
     
     /*
-    ListCloneSiteOperations lists all currently pending clone site operations
+    ListCloneSiteOperations lists all clone site operations
     */
     rpc ListCloneSiteOperations(ListCloneSiteOperationsRequest) returns (ListCloneSiteOperationsResponse) {
     }
     
     /*
-    ListSiteClones lists all clones for a particular origin site
+    ListClonesForSite lists all clones for a particular origin site
     */
-    rpc ListSiteClones(ListSiteClonesRequest) returns (ListSiteClonesResponse) {
+    rpc ListClonesForSite(ListClonesForSiteRequest) returns (ListClonesForSiteResponse) {
     }
 
     // Databases

--- a/live/sites/v1alpha1/service.proto
+++ b/live/sites/v1alpha1/service.proto
@@ -99,7 +99,7 @@ service Sites {
     /*
     CloneSite creates a clone of already existing site 
     */
-    rpc CloneSite(CloneSiteRequest) returns (CloneSiteResponse) {
+    rpc CloneSite(CloneRequest) returns (CloneResponse) {
     }
     
     /*

--- a/live/sites/v1alpha1/site.proto
+++ b/live/sites/v1alpha1/site.proto
@@ -295,19 +295,19 @@ message CloneOperation {
   `OutputOnly`
   Reference to the clone site operation 
   */
-  string cloneOperationRef = 1;
+  string ref = 1;
   
   /*
   `OutputOnly`
   Name of the origin site
   */
-  string originSiteName = 2;
+  string originSite = 2;
 
   /*
   `OutputOnly`
   Name of the new site
   */
-  string newCloneSiteName = 3;
+  string newSite = 3;
 
   /*
   `OutputOnly`
@@ -316,26 +316,26 @@ message CloneOperation {
   string status = 4;
 }
 
-message CloneSiteRequest {
+message CloneRequest {
 
   /*
   `Required`
   The name of the origin site
   */
-  string originSiteName = 1;
+  string originSite = 1;
 
   /*
   `Required`
   The name of the new site
   */
-  string newCloneSiteName = 2;
+  string newSite = 2;
   
   /*
   `Optional`
   Arguments to override git repository or revision
   */
   oneof Repository {
-    GitRepository git = 3;
+    GitRepository git = 16;
   }
 
   /*
@@ -351,12 +351,12 @@ message CloneSiteRequest {
   string fsBackup = 18;
 }
 
-message CloneSiteResponse {
+message CloneResponse {
   /*
   `OutputOnly`
   Reference to the clone site operation 
   */
-  string cloneOperationRef = 1;
+  string operationRef = 1;
 }
 
 message ListCloneSiteOperationsRequest {}
@@ -364,9 +364,9 @@ message ListCloneSiteOperationsRequest {}
 message ListCloneSiteOperationsResponse {
   /*
   `OutputOnly`
-  List of currently pending clone site operations
+  List of clone site operations
   */
-  repeated CloneOperation cloneOperations = 1;
+  repeated CloneOperation items = 1;
 }
 
 message ListClonesForSiteRequest {
@@ -374,7 +374,7 @@ message ListClonesForSiteRequest {
   `Required`
   List all clones for a particular origin site
   */
-  string originSiteName = 1;
+  string originSite = 1;
 }
 
 message ListClonesForSiteResponse {

--- a/live/sites/v1alpha1/site.proto
+++ b/live/sites/v1alpha1/site.proto
@@ -28,6 +28,12 @@ enum SiteType {
     WORDPRESS = 2;
 }
 
+enum CloneOperationState {
+    CLONE_CREATED = 0;
+    CLONE_SUCCEEDED = 1;
+    CLONE_FAILED = 2;
+}
+
 message GitRepository {
   /*
   The URL of the repository
@@ -311,9 +317,15 @@ message CloneOperation {
 
   /*
   `OutputOnly`
-  Status of the clone operation
+  State of the clone operation
   */
-  string status = 4;
+  CloneOperationState state = 4;
+  
+  /*
+  `OutputOnly`
+  Optionally contains additional human readable information describing the state of the operation
+  */
+  string info = 5;
 }
 
 message CloneRequest {

--- a/live/sites/v1alpha1/site.proto
+++ b/live/sites/v1alpha1/site.proto
@@ -30,13 +30,11 @@ enum SiteType {
 
 message GitRepository {
   /*
-  `Required`
   The URL of the repository
   */
   string url = 1;
 
   /*
-  `Required`
   The branch, tag, or commit.  Default: `master`.
   */
   string ref = 2;
@@ -289,6 +287,102 @@ message Typo3SiteOptions {
   A list of ephemeral mount paths relative to docroot
   */
   repeated string ephemeralPaths = 24;
+}
+
+message CloneOperation {
+
+  /*
+  `OutputOnly`
+  Reference to the clone site operation 
+  */
+  string cloneOperationRef = 1;
+  
+  /*
+  `OutputOnly`
+  Name of the origin site
+  */
+  string originSiteName = 2;
+
+  /*
+  `OutputOnly`
+  Name of the new site
+  */
+  string newCloneSiteName = 3;
+
+  /*
+  `OutputOnly`
+  Status of the clone operation
+  */
+  string status = 4;
+}
+
+message CloneSiteRequest {
+
+  /*
+  `Required`
+  The name of the origin site
+  */
+  string originSiteName = 1;
+
+  /*
+  `Required`
+  The name of the new site
+  */
+  string newCloneSiteName = 2;
+  
+  /*
+  `Optional`
+  Arguments to override git repository or revision
+  */
+  oneof Repository {
+    GitRepository git = 3;
+  }
+
+  /*
+  `Optional`
+  Override to use a db backup instead of the origin's site database
+  */
+  string dbBackup = 17;
+
+  /*
+  `Optional`
+  Override to the a filestore backup instead of the origin's site filestore
+  */
+  string fsBackup = 18;
+}
+
+message CloneSiteResponse {
+  /*
+  `OutputOnly`
+  Reference to the clone site operation 
+  */
+  string cloneOperationRef = 1;
+}
+
+message ListCloneSiteOperationsRequest {}
+
+message ListCloneSiteOperationsResponse {
+  /*
+  `OutputOnly`
+  List of currently pending clone site operations
+  */
+  repeated CloneOperation cloneOperations = 1;
+}
+
+message ListSiteClonesRequest {
+  /*
+  `Required`
+  List all clones for a particular origin site
+  */
+  string originSiteName = 1;
+}
+
+message ListSiteClonesResponse {
+  /*
+  `OutputOnly`
+  List all clones for a particular origin site
+  */
+  repeated Site clones = 1;
 }
 
 message CreateSiteRequest {

--- a/live/sites/v1alpha1/site.proto
+++ b/live/sites/v1alpha1/site.proto
@@ -369,7 +369,7 @@ message ListCloneSiteOperationsResponse {
   repeated CloneOperation cloneOperations = 1;
 }
 
-message ListSiteClonesRequest {
+message ListClonesForSiteRequest {
   /*
   `Required`
   List all clones for a particular origin site
@@ -377,7 +377,7 @@ message ListSiteClonesRequest {
   string originSiteName = 1;
 }
 
-message ListSiteClonesResponse {
+message ListClonesForSiteResponse {
   /*
   `OutputOnly`
   List all clones for a particular origin site


### PR DESCRIPTION
This PR contains API for relevant site cloning calls

There are three procedures:
1) Create site clone - from origin site, with desired clone site name, and optionally overriding db, filestore, or repository/revision. Returns reference to the site clone operation that will happen asynchronously and users can poll for the clone operation status.
2) List site clone operations
3) List clones for a particular origin site

related to: https://github.com/drud/ddev-live/issues/423, https://github.com/drud/ddev-live-ui/issues/439