### PR TITLE
ListSiteStream

### DIFF
--- a/doc/api/site-api.md
+++ b/doc/api/site-api.md
@@ -368,6 +368,7 @@ several metadata to be passed to the client.
 | CreateSite | [CreateSiteRequest](#ddev.sites.v1alpha1.CreateSiteRequest) | [CreateSiteResponse](#ddev.sites.v1alpha1.CreateSiteResponse) | CreateSite creates one of the supported site types |
 | GetSite | [GetSiteRequest](#ddev.sites.v1alpha1.GetSiteRequest) | [GetSiteResponse](#ddev.sites.v1alpha1.GetSiteResponse) | GetSite returns the state of a site by name |
 | ListSites | [ListSiteRequest](#ddev.sites.v1alpha1.ListSiteRequest) | [ListSiteResponse](#ddev.sites.v1alpha1.ListSiteResponse) | ListSites returns all sites within a workspace |
+| ListSiteStream | [ListSiteRequest](#ddev.sites.v1alpha1.ListSiteRequest) | [ListSiteResponse](#ddev.sites.v1alpha1.ListSiteResponse) stream | ListSiteStream returns all sites within a workspace and watches for any new sites or updates to previously returned sites |
 | UpdateSite | [UpdateSiteRequest](#ddev.sites.v1alpha1.UpdateSiteRequest) | [UpdateSiteResponse](#ddev.sites.v1alpha1.UpdateSiteResponse) |  |
 | DeleteSite | [DeleteSiteRequest](#ddev.sites.v1alpha1.DeleteSiteRequest) | [DeleteSiteResponse](#ddev.sites.v1alpha1.DeleteSiteResponse) |  |
 | SiteLogStream | [SiteLogsRequest](#ddev.sites.v1alpha1.SiteLogsRequest) | [SiteLogsResponse](#ddev.sites.v1alpha1.SiteLogsResponse) stream | SiteLogStream returns a stream of logs for a site |

--- a/live/sites/v1alpha1/service.proto
+++ b/live/sites/v1alpha1/service.proto
@@ -57,6 +57,12 @@ service Sites {
     }
 
     /*
+    ListSiteStream returns all sites within a workspace and watches for any new sites or updates to previously returned sites
+    */
+    rpc ListSiteStream(ListSiteRequest) returns (stream ListSiteResponse) {
+    }
+
+    /*
     */
     rpc UpdateSite(UpdateSiteRequest) returns (UpdateSiteResponse) {
     }


### PR DESCRIPTION
This proposed change introduces a method identical to `ListSite` however allows the client to listen for additions or changes to previously returned objects in the list.

_A current configurable restriction imposed by our gateway on our public host limits the duration streams can remain open._