### PR TITLE
Updating pull request template to avoid private issue tracking confusion

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,2 @@
 ## Which issue(s) this PR fixes:
+Fixes #

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,1 @@
-## Issue Link/Description:
+## Which issue(s) this PR fixes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,1 @@
-## Issue ID(s):
-
-## Tests:
-<!-- Tests introduced by this PR, manual steps to validate the fix, or an explanation for why no tests are needed. -->
-
-## Release/Deployment notes:
-<!-- Are there ramifications to other code? Does anything have to be done on deployment? -->
+## Description of the Feature/Issue:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,1 @@
-## Description of the Feature/Issue:
+## Issue Link/Description:


### PR DESCRIPTION
Updating the template using some [verbiage from kubernetes/kubernetes](https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md).  This repo only generates code so there will never be tests, and we should generate bazel and doc for the user eventually.

Internal tracking should link to the PR's instead of the other way around.