### PR TITLE
Create/update site additions

### DIFF
--- a/doc/api/administration-api.md
+++ b/doc/api/administration-api.md
@@ -3,58 +3,8 @@
 
 ## Table of Contents
 
-- [live/administration/v1alpha1/workspace.proto](#live/administration/v1alpha1/workspace.proto)
-    - [AddWorkspaceAdminRequest](#ddev.administration.v1alpha1.AddWorkspaceAdminRequest)
-    - [AddWorkspaceAdminResponse](#ddev.administration.v1alpha1.AddWorkspaceAdminResponse)
-    - [AddWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest)
-    - [AddWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse)
-    - [DeleteWorkspaceAdminRequest](#ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest)
-    - [DeleteWorkspaceAdminResponse](#ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse)
-    - [DeleteWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest)
-    - [DeleteWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse)
-    - [ListWorkspaceRequest](#ddev.administration.v1alpha1.ListWorkspaceRequest)
-    - [ListWorkspaceResponse](#ddev.administration.v1alpha1.ListWorkspaceResponse)
-    - [Workspace](#ddev.administration.v1alpha1.Workspace)
-  
-    - [ListWorkspaceRequest.ListWorkspaceScope](#ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope)
-  
-- [live/administration/v1alpha1/githubintegration.proto](#live/administration/v1alpha1/githubintegration.proto)
-    - [CreateGithubIntegrationRequest](#ddev.administration.v1alpha1.CreateGithubIntegrationRequest)
-    - [CreateGithubIntegrationResponse](#ddev.administration.v1alpha1.CreateGithubIntegrationResponse)
-    - [DeleteGithubIntegrationRequest](#ddev.administration.v1alpha1.DeleteGithubIntegrationRequest)
-    - [DeleteGithubIntegrationResponse](#ddev.administration.v1alpha1.DeleteGithubIntegrationResponse)
-    - [GetRepositoryMetadataRequest](#ddev.administration.v1alpha1.GetRepositoryMetadataRequest)
-    - [GetRepositoryMetadataResponse](#ddev.administration.v1alpha1.GetRepositoryMetadataResponse)
-    - [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest)
-    - [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse)
-    - [GithubRepositoryName](#ddev.administration.v1alpha1.GithubRepositoryName)
-    - [GithubRepositoryOwner](#ddev.administration.v1alpha1.GithubRepositoryOwner)
-    - [GithubRepositoryReference](#ddev.administration.v1alpha1.GithubRepositoryReference)
-    - [ListGithubRepositoriesRequest](#ddev.administration.v1alpha1.ListGithubRepositoriesRequest)
-    - [ListGithubRepositoriesResponse](#ddev.administration.v1alpha1.ListGithubRepositoriesResponse)
-    - [UpdateGithubIntegrationRequest](#ddev.administration.v1alpha1.UpdateGithubIntegrationRequest)
-    - [UpdateGithubIntegrationResponse](#ddev.administration.v1alpha1.UpdateGithubIntegrationResponse)
-  
-- [live/administration/v1alpha1/gitlabintegration.proto](#live/administration/v1alpha1/gitlabintegration.proto)
-    - [CreateGitlabIntegrationRequest](#ddev.administration.v1alpha1.CreateGitlabIntegrationRequest)
-    - [CreateGitlabIntegrationResponse](#ddev.administration.v1alpha1.CreateGitlabIntegrationResponse)
-    - [DeleteGitlabIntegrationRequest](#ddev.administration.v1alpha1.DeleteGitlabIntegrationRequest)
-    - [DeleteGitlabIntegrationResponse](#ddev.administration.v1alpha1.DeleteGitlabIntegrationResponse)
-    - [GetGitlabIntegrationRequest](#ddev.administration.v1alpha1.GetGitlabIntegrationRequest)
-    - [GetGitlabIntegrationResponse](#ddev.administration.v1alpha1.GetGitlabIntegrationResponse)
-    - [GetGitlabProjectMetadataRequest](#ddev.administration.v1alpha1.GetGitlabProjectMetadataRequest)
-    - [GetGitlabProjectMetadataResponse](#ddev.administration.v1alpha1.GetGitlabProjectMetadataResponse)
-    - [GitlabIntegration](#ddev.administration.v1alpha1.GitlabIntegration)
-    - [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse)
-    - [GitlabProjectName](#ddev.administration.v1alpha1.GitlabProjectName)
-    - [GitlabProjectOwner](#ddev.administration.v1alpha1.GitlabProjectOwner)
-    - [GitlabProjectReference](#ddev.administration.v1alpha1.GitlabProjectReference)
-    - [ListGitlabIntegrationsRequest](#ddev.administration.v1alpha1.ListGitlabIntegrationsRequest)
-    - [ListGitlabIntegrationsResponse](#ddev.administration.v1alpha1.ListGitlabIntegrationsResponse)
-    - [ListGitlabProjectsRequest](#ddev.administration.v1alpha1.ListGitlabProjectsRequest)
-    - [ListGitlabProjectsResponse](#ddev.administration.v1alpha1.ListGitlabProjectsResponse)
-  
-    - [ReferenceType](#ddev.administration.v1alpha1.ReferenceType)
+- [live/administration/v1alpha1/service.proto](#live/administration/v1alpha1/service.proto)
+    - [Administration](#ddev.administration.v1alpha1.Administration)
   
 - [live/administration/v1alpha1/auth.proto](#live/administration/v1alpha1/auth.proto)
     - [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest)
@@ -78,203 +28,67 @@
   
     - [Capability](#ddev.administration.v1alpha1.Capability)
   
-- [live/administration/v1alpha1/service.proto](#live/administration/v1alpha1/service.proto)
-    - [Administration](#ddev.administration.v1alpha1.Administration)
+- [live/administration/v1alpha1/githubintegration.proto](#live/administration/v1alpha1/githubintegration.proto)
+    - [CreateGithubIntegrationRequest](#ddev.administration.v1alpha1.CreateGithubIntegrationRequest)
+    - [CreateGithubIntegrationResponse](#ddev.administration.v1alpha1.CreateGithubIntegrationResponse)
+    - [DeleteGithubIntegrationRequest](#ddev.administration.v1alpha1.DeleteGithubIntegrationRequest)
+    - [DeleteGithubIntegrationResponse](#ddev.administration.v1alpha1.DeleteGithubIntegrationResponse)
+    - [GetRepositoryMetadataRequest](#ddev.administration.v1alpha1.GetRepositoryMetadataRequest)
+    - [GetRepositoryMetadataResponse](#ddev.administration.v1alpha1.GetRepositoryMetadataResponse)
+    - [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest)
+    - [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse)
+    - [GithubRepositoryName](#ddev.administration.v1alpha1.GithubRepositoryName)
+    - [GithubRepositoryOwner](#ddev.administration.v1alpha1.GithubRepositoryOwner)
+    - [GithubRepositoryReference](#ddev.administration.v1alpha1.GithubRepositoryReference)
+    - [ListGithubRepositoriesRequest](#ddev.administration.v1alpha1.ListGithubRepositoriesRequest)
+    - [ListGithubRepositoriesResponse](#ddev.administration.v1alpha1.ListGithubRepositoriesResponse)
+    - [UpdateGithubIntegrationRequest](#ddev.administration.v1alpha1.UpdateGithubIntegrationRequest)
+    - [UpdateGithubIntegrationResponse](#ddev.administration.v1alpha1.UpdateGithubIntegrationResponse)
+  
+- [live/administration/v1alpha1/workspace.proto](#live/administration/v1alpha1/workspace.proto)
+    - [AddWorkspaceAdminRequest](#ddev.administration.v1alpha1.AddWorkspaceAdminRequest)
+    - [AddWorkspaceAdminResponse](#ddev.administration.v1alpha1.AddWorkspaceAdminResponse)
+    - [AddWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest)
+    - [AddWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse)
+    - [DeleteWorkspaceAdminRequest](#ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest)
+    - [DeleteWorkspaceAdminResponse](#ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse)
+    - [DeleteWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest)
+    - [DeleteWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse)
+    - [ListWorkspaceRequest](#ddev.administration.v1alpha1.ListWorkspaceRequest)
+    - [ListWorkspaceResponse](#ddev.administration.v1alpha1.ListWorkspaceResponse)
+    - [Workspace](#ddev.administration.v1alpha1.Workspace)
+  
+    - [ListWorkspaceRequest.ListWorkspaceScope](#ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope)
+  
+- [live/administration/v1alpha1/gitlabintegration.proto](#live/administration/v1alpha1/gitlabintegration.proto)
+    - [CreateGitlabIntegrationRequest](#ddev.administration.v1alpha1.CreateGitlabIntegrationRequest)
+    - [CreateGitlabIntegrationResponse](#ddev.administration.v1alpha1.CreateGitlabIntegrationResponse)
+    - [DeleteGitlabIntegrationRequest](#ddev.administration.v1alpha1.DeleteGitlabIntegrationRequest)
+    - [DeleteGitlabIntegrationResponse](#ddev.administration.v1alpha1.DeleteGitlabIntegrationResponse)
+    - [GetGitlabIntegrationRequest](#ddev.administration.v1alpha1.GetGitlabIntegrationRequest)
+    - [GetGitlabIntegrationResponse](#ddev.administration.v1alpha1.GetGitlabIntegrationResponse)
+    - [GetGitlabProjectMetadataRequest](#ddev.administration.v1alpha1.GetGitlabProjectMetadataRequest)
+    - [GetGitlabProjectMetadataResponse](#ddev.administration.v1alpha1.GetGitlabProjectMetadataResponse)
+    - [GitlabIntegration](#ddev.administration.v1alpha1.GitlabIntegration)
+    - [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse)
+    - [GitlabProjectName](#ddev.administration.v1alpha1.GitlabProjectName)
+    - [GitlabProjectOwner](#ddev.administration.v1alpha1.GitlabProjectOwner)
+    - [GitlabProjectReference](#ddev.administration.v1alpha1.GitlabProjectReference)
+    - [ListGitlabIntegrationsRequest](#ddev.administration.v1alpha1.ListGitlabIntegrationsRequest)
+    - [ListGitlabIntegrationsResponse](#ddev.administration.v1alpha1.ListGitlabIntegrationsResponse)
+    - [ListGitlabProjectsRequest](#ddev.administration.v1alpha1.ListGitlabProjectsRequest)
+    - [ListGitlabProjectsResponse](#ddev.administration.v1alpha1.ListGitlabProjectsResponse)
+  
+    - [ReferenceType](#ddev.administration.v1alpha1.ReferenceType)
   
 - [Scalar Value Types](#scalar-value-types)
 
 
 
-<a name="live/administration/v1alpha1/workspace.proto"></a>
+<a name="live/administration/v1alpha1/service.proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## live/administration/v1alpha1/workspace.proto
-
-
-
-<a name="ddev.administration.v1alpha1.AddWorkspaceAdminRequest"></a>
-
-### AddWorkspaceAdminRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [string](#string) |  | `Required` The name of the workspace to add this administrator to. |
-| email | [string](#string) |  | `Required` The email of the workspace administrator |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.AddWorkspaceAdminResponse"></a>
-
-### AddWorkspaceAdminResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest"></a>
-
-### AddWorkspaceDeveloperRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [string](#string) |  | `Required` The name of the workspace to add this developer to. |
-| email | [string](#string) |  | `Required` The email of the workspace developer. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse"></a>
-
-### AddWorkspaceDeveloperResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest"></a>
-
-### DeleteWorkspaceAdminRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [string](#string) |  | `Required` The name of the workspace to remove this administrator from. |
-| email | [string](#string) |  | `Required` The email of the workspace administrator. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse"></a>
-
-### DeleteWorkspaceAdminResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest"></a>
-
-### DeleteWorkspaceDeveloperRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [string](#string) |  | `Required` The name of the workspace to remove this developer from. |
-| email | [string](#string) |  | `Required` The email of the workspace developer. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse"></a>
-
-### DeleteWorkspaceDeveloperResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListWorkspaceRequest"></a>
-
-### ListWorkspaceRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| Scope | [ListWorkspaceRequest.ListWorkspaceScope](#ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope) |  | `Optional` The scope of the list request. Defaults to `ListWorkspaceScope.DEVELOPER`. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListWorkspaceResponse"></a>
-
-### ListWorkspaceResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspaces | [Workspace](#ddev.administration.v1alpha1.Workspace) | repeated | `OutputOnly` - A workspace for the current user |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.Workspace"></a>
-
-### Workspace
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | `OutputOnly` Workspace Name. |
-| admins | [string](#string) | repeated | `OutputOnly` Administrators of the workspace |
-| developers | [string](#string) | repeated | `OutputOnly` Developers in the workspace |
-
-
-
-
-
- 
-
-
-<a name="ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope"></a>
-
-### ListWorkspaceRequest.ListWorkspaceScope
-Defines the scope of the request.  If the scope is set to ADMIN the response will contain only workspaces where the provided token user is an administrator.
-If the request is set to DEVELOPER the response will contain any workspace where the provided token user is an administrator or a developer.
-
-| Name | Number | Description |
-| ---- | ------ | ----------- |
-| DEVELOPER | 0 |  |
-| ADMIN | 1 |  |
+## live/administration/v1alpha1/service.proto
 
 
  
@@ -284,543 +98,55 @@ If the request is set to DEVELOPER the response will contain any workspace where
  
 
 
-
-<a name="live/administration/v1alpha1/githubintegration.proto"></a>
-<p align="right"><a href="#top">Top</a></p>
-
-## live/administration/v1alpha1/githubintegration.proto
-
-
-
-<a name="ddev.administration.v1alpha1.CreateGithubIntegrationRequest"></a>
-
-### CreateGithubIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The new GithubIntegration resource |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.CreateGithubIntegrationResponse"></a>
-
-### CreateGithubIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The new GithubIntegration resource |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteGithubIntegrationRequest"></a>
-
-### DeleteGithubIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The deleted GithubIntegration resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteGithubIntegrationResponse"></a>
-
-### DeleteGithubIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The deleted GithubIntegration resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GetRepositoryMetadataRequest"></a>
-
-### GetRepositoryMetadataRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `Required` The Repository ID. |
-| owner | [string](#string) |  | `Optional` The Repository owner. |
-| name | [string](#string) |  | `Optional` The Repository name. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GetRepositoryMetadataResponse"></a>
-
-### GetRepositoryMetadataResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `OutputOnly` The Repository ID. |
-| owner | [string](#string) |  | `OutputOnly` The Repository owner. |
-| name | [string](#string) |  | `OutputOnly` The Repository name. |
-| meta | [GithubRepositoryReference](#ddev.administration.v1alpha1.GithubRepositoryReference) | repeated | `OutputOnly` The Repository metadata. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubIntegrationRequest"></a>
-
-### GithubIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| installationID | [int64](#int64) |  | `Required` Installation ID. |
-| githubAppID | [int64](#int64) |  | `Required` Github App ID. |
-| githubAppSlug | [string](#string) |  | `Optional` Github App Slug. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubIntegrationResponse"></a>
-
-### GithubIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| installationID | [int64](#int64) |  | `Required` Installation ID. |
-| githubAppID | [int64](#int64) |  | `Required` Github App ID. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubRepositoryName"></a>
-
-### GithubRepositoryName
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `OutputOnly` The Repository ID. |
-| name | [string](#string) |  | `OutputOnly` The Repository name. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubRepositoryOwner"></a>
-
-### GithubRepositoryOwner
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | `OutputOnly` The Owner name. |
-| repositories | [GithubRepositoryName](#ddev.administration.v1alpha1.GithubRepositoryName) | repeated | `OutputOnly` List of Repository Names for this Owner. |
-| installationID | [string](#string) |  | `OutputOnly` The Installation ID of this Owner&#39;s GitHub App installation. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubRepositoryReference"></a>
-
-### GithubRepositoryReference
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| sha | [string](#string) |  | `OutputOnly` Reference commit sha. |
-| branch | [string](#string) |  |  |
-| tag | [string](#string) |  |  |
-| pullrequest | [string](#string) |  |  |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListGithubRepositoriesRequest"></a>
-
-### ListGithubRepositoriesRequest
-
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListGithubRepositoriesResponse"></a>
-
-### ListGithubRepositoriesResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| items | [GithubRepositoryOwner](#ddev.administration.v1alpha1.GithubRepositoryOwner) | repeated | `OutputOnly` Github repositories available to the user. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.UpdateGithubIntegrationRequest"></a>
-
-### UpdateGithubIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The updated GithubIntegration resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.UpdateGithubIntegrationResponse"></a>
-
-### UpdateGithubIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The updated GithubIntegration resource. |
-
-
-
-
-
- 
-
- 
-
- 
-
- 
-
-
-
-<a name="live/administration/v1alpha1/gitlabintegration.proto"></a>
-<p align="right"><a href="#top">Top</a></p>
-
-## live/administration/v1alpha1/gitlabintegration.proto
-
-
-
-<a name="ddev.administration.v1alpha1.CreateGitlabIntegrationRequest"></a>
-
-### CreateGitlabIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `Required` Gitlab integration ID. |
-| host | [string](#string) |  | `Required` Gitlab server URL. |
-| username | [string](#string) |  | `Required` Username for the token. |
-| token | [string](#string) |  | `Required` Gitlab Personal Access Token. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.CreateGitlabIntegrationResponse"></a>
-
-### CreateGitlabIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) |  | `OutputOnly` The new GitlabIntegration resource |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteGitlabIntegrationRequest"></a>
-
-### DeleteGitlabIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `Required` Gitlab integration ID. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteGitlabIntegrationResponse"></a>
-
-### DeleteGitlabIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) |  | `OutputOnly` The deleted GitlabIntegration resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GetGitlabIntegrationRequest"></a>
-
-### GetGitlabIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `Required` Gitlab integration ID. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GetGitlabIntegrationResponse"></a>
-
-### GetGitlabIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) |  | `OutputOnly` Gitlab integration. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GetGitlabProjectMetadataRequest"></a>
-
-### GetGitlabProjectMetadataRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integrationID | [string](#string) |  | `Required` Integration ID. |
-| projectID | [string](#string) |  | `Required` Project ID. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GetGitlabProjectMetadataResponse"></a>
-
-### GetGitlabProjectMetadataResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `OutputOnly` The Project ID. |
-| meta | [GitlabProjectReference](#ddev.administration.v1alpha1.GitlabProjectReference) | repeated | `OutputOnly` The Project metadata. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GitlabIntegration"></a>
-
-### GitlabIntegration
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `OutputOnly` Gitlab integration ID. |
-| owners | [GitlabProjectOwner](#ddev.administration.v1alpha1.GitlabProjectOwner) | repeated | `OutputOnly` Gitlab projects available to the user. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GitlabIntegrationResponse"></a>
-
-### GitlabIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `OutputOnly` Gitlab integration ID. |
-| host | [string](#string) |  | `OutputOnly` Gitlab server URL. |
-| username | [string](#string) |  | `OutputOnly` Username for the token. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GitlabProjectName"></a>
-
-### GitlabProjectName
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `OutputOnly` The Project ID. |
-| name | [string](#string) |  | `OutputOnly` The Project name. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GitlabProjectOwner"></a>
-
-### GitlabProjectOwner
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | `OutputOnly` Gitlab account username. |
-| projects | [GitlabProjectName](#ddev.administration.v1alpha1.GitlabProjectName) | repeated | `OutputOnly` List of Project Names for this Owner. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GitlabProjectReference"></a>
-
-### GitlabProjectReference
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| sha | [string](#string) |  | `OutputOnly` Reference commit sha. |
-| ref | [string](#string) |  | `OutputOnly` Reference type. |
-| type | [ReferenceType](#ddev.administration.v1alpha1.ReferenceType) |  | `OutputOnly` Reference type (branch, tag, mr). |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListGitlabIntegrationsRequest"></a>
-
-### ListGitlabIntegrationsRequest
-
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListGitlabIntegrationsResponse"></a>
-
-### ListGitlabIntegrationsResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integrations | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) | repeated | `OutputOnly` Gitlab integrations. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListGitlabProjectsRequest"></a>
-
-### ListGitlabProjectsRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `Optional` Gitlab integration ID. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListGitlabProjectsResponse"></a>
-
-### ListGitlabProjectsResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integrations | [GitlabIntegration](#ddev.administration.v1alpha1.GitlabIntegration) | repeated | `OutputOnly` Gitlab integrations available to the user. |
-
-
-
-
-
- 
-
-
-<a name="ddev.administration.v1alpha1.ReferenceType"></a>
-
-### ReferenceType
-
-
-| Name | Number | Description |
-| ---- | ------ | ----------- |
-| Branch | 0 |  |
-| Tag | 1 |  |
-| MR | 2 |  |
-
-
- 
-
- 
+<a name="ddev.administration.v1alpha1.Administration"></a>
+
+### Administration
+The Billing service provides administrative functions over a users ddev-live account.
+To access the billing service consumers will have to initialize an authenticated client.  This requires
+several metadata to be passed to the client.
+
+`x-auth-token` which is a authentication token for the call.  In most cases this will be a temporary token 
+issued by the API.  This can be the integration token provided on the dashboard when retrieving temporary tokens.
+
+`x-ddev-workspace` which is the workspace for all workspace scoped procedures.  For example a client request `ListSubscriptions` will list all subscriptions in the workspace whose value is derived from the key `x-ddev-workspace`.
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| CreateToken | [CreateTokenRequest](#ddev.administration.v1alpha1.CreateTokenRequest) | [CreateTokenResponse](#ddev.administration.v1alpha1.CreateTokenResponse) | Creates an ID token from a refresh token |
+| CreateRoles | [CreateRoleRequest](#ddev.administration.v1alpha1.CreateRoleRequest) | [CreateRoleResponse](#ddev.administration.v1alpha1.CreateRoleResponse) | Creates a Role |
+| DescribeRole | [DescribeRoleRequest](#ddev.administration.v1alpha1.DescribeRoleRequest) | [DescribeRoleResponse](#ddev.administration.v1alpha1.DescribeRoleResponse) | Describes a named role |
+| ListRoles | [ListRolesRequest](#ddev.administration.v1alpha1.ListRolesRequest) | [ListRolesResponse](#ddev.administration.v1alpha1.ListRolesResponse) | Lists all known roles |
+| SetCapabilities | [SetCapabilitiesRequest](#ddev.administration.v1alpha1.SetCapabilitiesRequest) | [SetCapabilitiesResponse](#ddev.administration.v1alpha1.SetCapabilitiesResponse) | Updates a users API capabilities. Will requre a refresh of their token through CreateToken. |
+| ListCapabilities | [ListCapabilitiesRequest](#ddev.administration.v1alpha1.ListCapabilitiesRequest) | [ListCapabilitiesResponse](#ddev.administration.v1alpha1.ListCapabilitiesResponse) | Lists a users API capabilities. |
+| ListWorkspaces | [ListWorkspaceRequest](#ddev.administration.v1alpha1.ListWorkspaceRequest) | [ListWorkspaceResponse](#ddev.administration.v1alpha1.ListWorkspaceResponse) | ListWorkspaces will return a list of workspaces the user has authorization for |
+| AddWorkspaceAdmin | [AddWorkspaceAdminRequest](#ddev.administration.v1alpha1.AddWorkspaceAdminRequest) | [AddWorkspaceAdminResponse](#ddev.administration.v1alpha1.AddWorkspaceAdminResponse) | Add an administrator to a workspace. Requires a workspace administrator token. |
+| AddWorkspaceDeveloper | [AddWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest) | [AddWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse) | Add a developer to a workspace. Requires a workspace administrator token. |
+| DeleteWorkspaceAdmin | [DeleteWorkspaceAdminRequest](#ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest) | [DeleteWorkspaceAdminResponse](#ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse) | Remove an administrator from a workspace. Requires a workspace administrator token. An administrator cannot remove themselves. |
+| DeleteWorkspaceDeveloper | [DeleteWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest) | [DeleteWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse) | Remove a developer from a workspace. Requires a workspace administrator token. |
+| IsAuthTokenViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can read the API scopes a user has. |
+| IsAuthTokenEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can issue different API access scopes within an organization |
+| IsBillingViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can access billing artifacts such as invoices |
+| IsBillingEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can modify elements such as their subscription |
+| IsWorkspaceAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is an admin of a workspace |
+| IsWorkspaceViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which has read capability for workspace objects |
+| IsSiteEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is capable of creating or modifying a site |
+| IsSiteViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is capable of viewing site specifications created in a workspace |
+| IsLogsViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows for the viewing of site logs |
+| IsSiteExecutor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows for the execution of commands inside a running site container |
+| IsDatabaseAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows full control over site databases, which includes restore and push operations |
+| IsDatabaseViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows pull access for a sites database |
+| IsFileAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows full control over site files, which includes restore and push operations |
+| IsFileViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows pull access for a sites files |
+| CreateGithubIntegration | [CreateGithubIntegrationRequest](#ddev.administration.v1alpha1.CreateGithubIntegrationRequest) | [CreateGithubIntegrationResponse](#ddev.administration.v1alpha1.CreateGithubIntegrationResponse) | Creates a github integration from an installation ID |
+| DeleteGithubIntegration | [DeleteGithubIntegrationRequest](#ddev.administration.v1alpha1.DeleteGithubIntegrationRequest) | [DeleteGithubIntegrationResponse](#ddev.administration.v1alpha1.DeleteGithubIntegrationResponse) | Deletes a github integration |
+| UpdateGithubIntegration | [UpdateGithubIntegrationRequest](#ddev.administration.v1alpha1.UpdateGithubIntegrationRequest) | [UpdateGithubIntegrationResponse](#ddev.administration.v1alpha1.UpdateGithubIntegrationResponse) | Updates a github integration |
+| ListGithubRepositories | [ListGithubRepositoriesRequest](#ddev.administration.v1alpha1.ListGithubRepositoriesRequest) | [ListGithubRepositoriesResponse](#ddev.administration.v1alpha1.ListGithubRepositoriesResponse) | List github repositories |
+| CreateGitlabIntegration | [CreateGitlabIntegrationRequest](#ddev.administration.v1alpha1.CreateGitlabIntegrationRequest) | [CreateGitlabIntegrationResponse](#ddev.administration.v1alpha1.CreateGitlabIntegrationResponse) | Creates a gitlab integration from an installation ID |
+| DeleteGitlabIntegration | [DeleteGitlabIntegrationRequest](#ddev.administration.v1alpha1.DeleteGitlabIntegrationRequest) | [DeleteGitlabIntegrationResponse](#ddev.administration.v1alpha1.DeleteGitlabIntegrationResponse) | Deletes a gitlab integration |
+| ListGitlabIntegrations | [ListGitlabIntegrationsRequest](#ddev.administration.v1alpha1.ListGitlabIntegrationsRequest) | [ListGitlabIntegrationsResponse](#ddev.administration.v1alpha1.ListGitlabIntegrationsResponse) | Lists gitlab integrations |
+| ListGitlabProjects | [ListGitlabProjectsRequest](#ddev.administration.v1alpha1.ListGitlabProjectsRequest) | [ListGitlabProjectsResponse](#ddev.administration.v1alpha1.ListGitlabProjectsResponse) | List gitlab projects |
+| GetGitlabProjectMetadata | [GetGitlabProjectMetadataRequest](#ddev.administration.v1alpha1.GetGitlabProjectMetadataRequest) | [GetGitlabProjectMetadataResponse](#ddev.administration.v1alpha1.GetGitlabProjectMetadataResponse) | Returns metadata of a Gitlab project by ID |
+| GetRepositoryMetadata | [GetRepositoryMetadataRequest](#ddev.administration.v1alpha1.GetRepositoryMetadataRequest) | [GetRepositoryMetadataResponse](#ddev.administration.v1alpha1.GetRepositoryMetadataResponse) | Returns metadata of a repository by ID |
 
  
 
@@ -1138,10 +464,446 @@ Describes a set of access policies for a user
 
 
 
-<a name="live/administration/v1alpha1/service.proto"></a>
+<a name="live/administration/v1alpha1/githubintegration.proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## live/administration/v1alpha1/service.proto
+## live/administration/v1alpha1/githubintegration.proto
+
+
+
+<a name="ddev.administration.v1alpha1.CreateGithubIntegrationRequest"></a>
+
+### CreateGithubIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The new GithubIntegration resource |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.CreateGithubIntegrationResponse"></a>
+
+### CreateGithubIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The new GithubIntegration resource |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteGithubIntegrationRequest"></a>
+
+### DeleteGithubIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The deleted GithubIntegration resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteGithubIntegrationResponse"></a>
+
+### DeleteGithubIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The deleted GithubIntegration resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetRepositoryMetadataRequest"></a>
+
+### GetRepositoryMetadataRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `Required` The Repository ID. |
+| owner | [string](#string) |  | `Optional` The Repository owner. |
+| name | [string](#string) |  | `Optional` The Repository name. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetRepositoryMetadataResponse"></a>
+
+### GetRepositoryMetadataResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `OutputOnly` The Repository ID. |
+| owner | [string](#string) |  | `OutputOnly` The Repository owner. |
+| name | [string](#string) |  | `OutputOnly` The Repository name. |
+| meta | [GithubRepositoryReference](#ddev.administration.v1alpha1.GithubRepositoryReference) | repeated | `OutputOnly` The Repository metadata. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubIntegrationRequest"></a>
+
+### GithubIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| installationID | [int64](#int64) |  | `Required` Installation ID. |
+| githubAppID | [int64](#int64) |  | `Required` Github App ID. |
+| githubAppSlug | [string](#string) |  | `Optional` Github App Slug. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubIntegrationResponse"></a>
+
+### GithubIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| installationID | [int64](#int64) |  | `Required` Installation ID. |
+| githubAppID | [int64](#int64) |  | `Required` Github App ID. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubRepositoryName"></a>
+
+### GithubRepositoryName
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `OutputOnly` The Repository ID. |
+| name | [string](#string) |  | `OutputOnly` The Repository name. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubRepositoryOwner"></a>
+
+### GithubRepositoryOwner
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | `OutputOnly` The Owner name. |
+| repositories | [GithubRepositoryName](#ddev.administration.v1alpha1.GithubRepositoryName) | repeated | `OutputOnly` List of Repository Names for this Owner. |
+| installationID | [string](#string) |  | `OutputOnly` The Installation ID of this Owner&#39;s GitHub App installation. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubRepositoryReference"></a>
+
+### GithubRepositoryReference
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| sha | [string](#string) |  | `OutputOnly` Reference commit sha. |
+| branch | [string](#string) |  |  |
+| tag | [string](#string) |  |  |
+| pullrequest | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListGithubRepositoriesRequest"></a>
+
+### ListGithubRepositoriesRequest
+
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListGithubRepositoriesResponse"></a>
+
+### ListGithubRepositoriesResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| items | [GithubRepositoryOwner](#ddev.administration.v1alpha1.GithubRepositoryOwner) | repeated | `OutputOnly` Github repositories available to the user. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.UpdateGithubIntegrationRequest"></a>
+
+### UpdateGithubIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The updated GithubIntegration resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.UpdateGithubIntegrationResponse"></a>
+
+### UpdateGithubIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The updated GithubIntegration resource. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="live/administration/v1alpha1/workspace.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## live/administration/v1alpha1/workspace.proto
+
+
+
+<a name="ddev.administration.v1alpha1.AddWorkspaceAdminRequest"></a>
+
+### AddWorkspaceAdminRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [string](#string) |  | `Required` The name of the workspace to add this administrator to. |
+| email | [string](#string) |  | `Required` The email of the workspace administrator |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.AddWorkspaceAdminResponse"></a>
+
+### AddWorkspaceAdminResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest"></a>
+
+### AddWorkspaceDeveloperRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [string](#string) |  | `Required` The name of the workspace to add this developer to. |
+| email | [string](#string) |  | `Required` The email of the workspace developer. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse"></a>
+
+### AddWorkspaceDeveloperResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest"></a>
+
+### DeleteWorkspaceAdminRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [string](#string) |  | `Required` The name of the workspace to remove this administrator from. |
+| email | [string](#string) |  | `Required` The email of the workspace administrator. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse"></a>
+
+### DeleteWorkspaceAdminResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest"></a>
+
+### DeleteWorkspaceDeveloperRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [string](#string) |  | `Required` The name of the workspace to remove this developer from. |
+| email | [string](#string) |  | `Required` The email of the workspace developer. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse"></a>
+
+### DeleteWorkspaceDeveloperResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListWorkspaceRequest"></a>
+
+### ListWorkspaceRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| Scope | [ListWorkspaceRequest.ListWorkspaceScope](#ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope) |  | `Optional` The scope of the list request. Defaults to `ListWorkspaceScope.DEVELOPER`. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListWorkspaceResponse"></a>
+
+### ListWorkspaceResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspaces | [Workspace](#ddev.administration.v1alpha1.Workspace) | repeated | `OutputOnly` - A workspace for the current user |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.Workspace"></a>
+
+### Workspace
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | `OutputOnly` Workspace Name. |
+| admins | [string](#string) | repeated | `OutputOnly` Administrators of the workspace |
+| developers | [string](#string) | repeated | `OutputOnly` Developers in the workspace |
+
+
+
+
+
+ 
+
+
+<a name="ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope"></a>
+
+### ListWorkspaceRequest.ListWorkspaceScope
+Defines the scope of the request.  If the scope is set to ADMIN the response will contain only workspaces where the provided token user is an administrator.
+If the request is set to DEVELOPER the response will contain any workspace where the provided token user is an administrator or a developer.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| DEVELOPER | 0 |  |
+| ADMIN | 1 |  |
 
 
  
@@ -1151,55 +913,293 @@ Describes a set of access policies for a user
  
 
 
-<a name="ddev.administration.v1alpha1.Administration"></a>
 
-### Administration
-The Billing service provides administrative functions over a users ddev-live account.
-To access the billing service consumers will have to initialize an authenticated client.  This requires
-several metadata to be passed to the client.
+<a name="live/administration/v1alpha1/gitlabintegration.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
 
-`x-auth-token` which is a authentication token for the call.  In most cases this will be a temporary token 
-issued by the API.  This can be the integration token provided on the dashboard when retrieving temporary tokens.
+## live/administration/v1alpha1/gitlabintegration.proto
 
-`x-ddev-workspace` which is the workspace for all workspace scoped procedures.  For example a client request `ListSubscriptions` will list all subscriptions in the workspace whose value is derived from the key `x-ddev-workspace`.
 
-| Method Name | Request Type | Response Type | Description |
-| ----------- | ------------ | ------------- | ------------|
-| CreateToken | [CreateTokenRequest](#ddev.administration.v1alpha1.CreateTokenRequest) | [CreateTokenResponse](#ddev.administration.v1alpha1.CreateTokenResponse) | Creates an ID token from a refresh token |
-| CreateRoles | [CreateRoleRequest](#ddev.administration.v1alpha1.CreateRoleRequest) | [CreateRoleResponse](#ddev.administration.v1alpha1.CreateRoleResponse) | Creates a Role |
-| DescribeRole | [DescribeRoleRequest](#ddev.administration.v1alpha1.DescribeRoleRequest) | [DescribeRoleResponse](#ddev.administration.v1alpha1.DescribeRoleResponse) | Describes a named role |
-| ListRoles | [ListRolesRequest](#ddev.administration.v1alpha1.ListRolesRequest) | [ListRolesResponse](#ddev.administration.v1alpha1.ListRolesResponse) | Lists all known roles |
-| SetCapabilities | [SetCapabilitiesRequest](#ddev.administration.v1alpha1.SetCapabilitiesRequest) | [SetCapabilitiesResponse](#ddev.administration.v1alpha1.SetCapabilitiesResponse) | Updates a users API capabilities. Will requre a refresh of their token through CreateToken. |
-| ListCapabilities | [ListCapabilitiesRequest](#ddev.administration.v1alpha1.ListCapabilitiesRequest) | [ListCapabilitiesResponse](#ddev.administration.v1alpha1.ListCapabilitiesResponse) | Lists a users API capabilities. |
-| ListWorkspaces | [ListWorkspaceRequest](#ddev.administration.v1alpha1.ListWorkspaceRequest) | [ListWorkspaceResponse](#ddev.administration.v1alpha1.ListWorkspaceResponse) | ListWorkspaces will return a list of workspaces the user has authorization for |
-| AddWorkspaceAdmin | [AddWorkspaceAdminRequest](#ddev.administration.v1alpha1.AddWorkspaceAdminRequest) | [AddWorkspaceAdminResponse](#ddev.administration.v1alpha1.AddWorkspaceAdminResponse) | Add an administrator to a workspace. Requires a workspace administrator token. |
-| AddWorkspaceDeveloper | [AddWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest) | [AddWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse) | Add a developer to a workspace. Requires a workspace administrator token. |
-| DeleteWorkspaceAdmin | [DeleteWorkspaceAdminRequest](#ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest) | [DeleteWorkspaceAdminResponse](#ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse) | Remove an administrator from a workspace. Requires a workspace administrator token. An administrator cannot remove themselves. |
-| DeleteWorkspaceDeveloper | [DeleteWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest) | [DeleteWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse) | Remove a developer from a workspace. Requires a workspace administrator token. |
-| IsAuthTokenViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can read the API scopes a user has. |
-| IsAuthTokenEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can issue different API access scopes within an organization |
-| IsBillingViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can access billing artifacts such as invoices |
-| IsBillingEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can modify elements such as their subscription |
-| IsWorkspaceAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is an admin of a workspace |
-| IsWorkspaceViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which has read capability for workspace objects |
-| IsSiteEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is capable of creating or modifying a site |
-| IsSiteViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is capable of viewing site specifications created in a workspace |
-| IsLogsViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows for the viewing of site logs |
-| IsSiteExecutor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows for the execution of commands inside a running site container |
-| IsDatabaseAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows full control over site databases, which includes restore and push operations |
-| IsDatabaseViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows pull access for a sites database |
-| IsFileAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows full control over site files, which includes restore and push operations |
-| IsFileViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows pull access for a sites files |
-| CreateGithubIntegration | [CreateGithubIntegrationRequest](#ddev.administration.v1alpha1.CreateGithubIntegrationRequest) | [CreateGithubIntegrationResponse](#ddev.administration.v1alpha1.CreateGithubIntegrationResponse) | Creates a github integration from an installation ID |
-| DeleteGithubIntegration | [DeleteGithubIntegrationRequest](#ddev.administration.v1alpha1.DeleteGithubIntegrationRequest) | [DeleteGithubIntegrationResponse](#ddev.administration.v1alpha1.DeleteGithubIntegrationResponse) | Deletes a github integration |
-| UpdateGithubIntegration | [UpdateGithubIntegrationRequest](#ddev.administration.v1alpha1.UpdateGithubIntegrationRequest) | [UpdateGithubIntegrationResponse](#ddev.administration.v1alpha1.UpdateGithubIntegrationResponse) | Updates a github integration |
-| ListGithubRepositories | [ListGithubRepositoriesRequest](#ddev.administration.v1alpha1.ListGithubRepositoriesRequest) | [ListGithubRepositoriesResponse](#ddev.administration.v1alpha1.ListGithubRepositoriesResponse) | List github repositories |
-| CreateGitlabIntegration | [CreateGitlabIntegrationRequest](#ddev.administration.v1alpha1.CreateGitlabIntegrationRequest) | [CreateGitlabIntegrationResponse](#ddev.administration.v1alpha1.CreateGitlabIntegrationResponse) | Creates a gitlab integration from an installation ID |
-| DeleteGitlabIntegration | [DeleteGitlabIntegrationRequest](#ddev.administration.v1alpha1.DeleteGitlabIntegrationRequest) | [DeleteGitlabIntegrationResponse](#ddev.administration.v1alpha1.DeleteGitlabIntegrationResponse) | Deletes a gitlab integration |
-| ListGitlabIntegrations | [ListGitlabIntegrationsRequest](#ddev.administration.v1alpha1.ListGitlabIntegrationsRequest) | [ListGitlabIntegrationsResponse](#ddev.administration.v1alpha1.ListGitlabIntegrationsResponse) | Lists gitlab integrations |
-| ListGitlabProjects | [ListGitlabProjectsRequest](#ddev.administration.v1alpha1.ListGitlabProjectsRequest) | [ListGitlabProjectsResponse](#ddev.administration.v1alpha1.ListGitlabProjectsResponse) | List gitlab projects |
-| GetGitlabProjectMetadata | [GetGitlabProjectMetadataRequest](#ddev.administration.v1alpha1.GetGitlabProjectMetadataRequest) | [GetGitlabProjectMetadataResponse](#ddev.administration.v1alpha1.GetGitlabProjectMetadataResponse) | Returns metadata of a Gitlab project by ID |
-| GetRepositoryMetadata | [GetRepositoryMetadataRequest](#ddev.administration.v1alpha1.GetRepositoryMetadataRequest) | [GetRepositoryMetadataResponse](#ddev.administration.v1alpha1.GetRepositoryMetadataResponse) | Returns metadata of a repository by ID |
+
+<a name="ddev.administration.v1alpha1.CreateGitlabIntegrationRequest"></a>
+
+### CreateGitlabIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `Required` Gitlab integration ID. |
+| host | [string](#string) |  | `Required` Gitlab server URL. |
+| username | [string](#string) |  | `Required` Username for the token. |
+| token | [string](#string) |  | `Required` Gitlab Personal Access Token. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.CreateGitlabIntegrationResponse"></a>
+
+### CreateGitlabIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) |  | `OutputOnly` The new GitlabIntegration resource |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteGitlabIntegrationRequest"></a>
+
+### DeleteGitlabIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `Required` Gitlab integration ID. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteGitlabIntegrationResponse"></a>
+
+### DeleteGitlabIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) |  | `OutputOnly` The deleted GitlabIntegration resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetGitlabIntegrationRequest"></a>
+
+### GetGitlabIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `Required` Gitlab integration ID. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetGitlabIntegrationResponse"></a>
+
+### GetGitlabIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) |  | `OutputOnly` Gitlab integration. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetGitlabProjectMetadataRequest"></a>
+
+### GetGitlabProjectMetadataRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integrationID | [string](#string) |  | `Required` Integration ID. |
+| projectID | [string](#string) |  | `Required` Project ID. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetGitlabProjectMetadataResponse"></a>
+
+### GetGitlabProjectMetadataResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `OutputOnly` The Project ID. |
+| meta | [GitlabProjectReference](#ddev.administration.v1alpha1.GitlabProjectReference) | repeated | `OutputOnly` The Project metadata. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GitlabIntegration"></a>
+
+### GitlabIntegration
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `OutputOnly` Gitlab integration ID. |
+| owners | [GitlabProjectOwner](#ddev.administration.v1alpha1.GitlabProjectOwner) | repeated | `OutputOnly` Gitlab projects available to the user. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GitlabIntegrationResponse"></a>
+
+### GitlabIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `OutputOnly` Gitlab integration ID. |
+| host | [string](#string) |  | `OutputOnly` Gitlab server URL. |
+| username | [string](#string) |  | `OutputOnly` Username for the token. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GitlabProjectName"></a>
+
+### GitlabProjectName
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `OutputOnly` The Project ID. |
+| name | [string](#string) |  | `OutputOnly` The Project name. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GitlabProjectOwner"></a>
+
+### GitlabProjectOwner
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | `OutputOnly` Gitlab account username. |
+| projects | [GitlabProjectName](#ddev.administration.v1alpha1.GitlabProjectName) | repeated | `OutputOnly` List of Project Names for this Owner. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GitlabProjectReference"></a>
+
+### GitlabProjectReference
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| sha | [string](#string) |  | `OutputOnly` Reference commit sha. |
+| ref | [string](#string) |  | `OutputOnly` Reference type. |
+| type | [ReferenceType](#ddev.administration.v1alpha1.ReferenceType) |  | `OutputOnly` Reference type (branch, tag, mr). |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListGitlabIntegrationsRequest"></a>
+
+### ListGitlabIntegrationsRequest
+
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListGitlabIntegrationsResponse"></a>
+
+### ListGitlabIntegrationsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integrations | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) | repeated | `OutputOnly` Gitlab integrations. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListGitlabProjectsRequest"></a>
+
+### ListGitlabProjectsRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `Optional` Gitlab integration ID. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListGitlabProjectsResponse"></a>
+
+### ListGitlabProjectsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integrations | [GitlabIntegration](#ddev.administration.v1alpha1.GitlabIntegration) | repeated | `OutputOnly` Gitlab integrations available to the user. |
+
+
+
+
+
+ 
+
+
+<a name="ddev.administration.v1alpha1.ReferenceType"></a>
+
+### ReferenceType
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| Branch | 0 |  |
+| Tag | 1 |  |
+| MR | 2 |  |
+
+
+ 
+
+ 
 
  
 

--- a/doc/api/administration-api.md
+++ b/doc/api/administration-api.md
@@ -717,200 +717,192 @@ Describes a set of access policies for a user
 <a name="live/administration/v1alpha1/workspace.proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## live/administration/v1alpha1/workspace.proto
+## live/administration/v1alpha1/githubintegration.proto
 
 
 
-<a name="ddev.administration.v1alpha1.AddWorkspaceAdminRequest"></a>
+<a name="ddev.administration.v1alpha1.CreateGithubIntegrationRequest"></a>
 
-### AddWorkspaceAdminRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [string](#string) |  | `Required` The name of the workspace to add this administrator to. |
-| email | [string](#string) |  | `Required` The email of the workspace administrator |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.AddWorkspaceAdminResponse"></a>
-
-### AddWorkspaceAdminResponse
+### CreateGithubIntegrationRequest
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
+| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The new GithubIntegration resource |
 
 
 
 
 
 
-<a name="ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest"></a>
+<a name="ddev.administration.v1alpha1.CreateGithubIntegrationResponse"></a>
 
-### AddWorkspaceDeveloperRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [string](#string) |  | `Required` The name of the workspace to add this developer to. |
-| email | [string](#string) |  | `Required` The email of the workspace developer. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse"></a>
-
-### AddWorkspaceDeveloperResponse
+### CreateGithubIntegrationResponse
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
+| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The new GithubIntegration resource |
 
 
 
 
 
 
-<a name="ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest"></a>
+<a name="ddev.administration.v1alpha1.DeleteGithubIntegrationRequest"></a>
 
-### DeleteWorkspaceAdminRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [string](#string) |  | `Required` The name of the workspace to remove this administrator from. |
-| email | [string](#string) |  | `Required` The email of the workspace administrator. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse"></a>
-
-### DeleteWorkspaceAdminResponse
+### DeleteGithubIntegrationRequest
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
+| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The deleted GithubIntegration resource. |
 
 
 
 
 
 
-<a name="ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest"></a>
+<a name="ddev.administration.v1alpha1.DeleteGithubIntegrationResponse"></a>
 
-### DeleteWorkspaceDeveloperRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [string](#string) |  | `Required` The name of the workspace to remove this developer from. |
-| email | [string](#string) |  | `Required` The email of the workspace developer. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse"></a>
-
-### DeleteWorkspaceDeveloperResponse
+### DeleteGithubIntegrationResponse
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
+| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The deleted GithubIntegration resource. |
 
 
 
 
 
 
-<a name="ddev.administration.v1alpha1.ListWorkspaceRequest"></a>
+<a name="ddev.administration.v1alpha1.GetRepositoryMetadataRequest"></a>
 
-### ListWorkspaceRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| Scope | [ListWorkspaceRequest.ListWorkspaceScope](#ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope) |  | `Optional` The scope of the list request. Defaults to `ListWorkspaceScope.DEVELOPER`. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListWorkspaceResponse"></a>
-
-### ListWorkspaceResponse
+### GetRepositoryMetadataRequest
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| workspaces | [Workspace](#ddev.administration.v1alpha1.Workspace) | repeated | `OutputOnly` - A workspace for the current user |
+| id | [string](#string) |  | `Required` The Repository ID. |
+| owner | [string](#string) |  | `Optional` The Repository owner. |
+| name | [string](#string) |  | `Optional` The Repository name. |
 
 
 
 
 
 
-<a name="ddev.administration.v1alpha1.Workspace"></a>
+<a name="ddev.administration.v1alpha1.GetRepositoryMetadataResponse"></a>
 
-### Workspace
+### GetRepositoryMetadataResponse
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | `OutputOnly` Workspace Name. |
-| admins | [string](#string) | repeated | `OutputOnly` Administrators of the workspace |
-| developers | [string](#string) | repeated | `OutputOnly` Developers in the workspace |
+| id | [string](#string) |  | `OutputOnly` The Repository ID. |
+| owner | [string](#string) |  | `OutputOnly` The Repository owner. |
+| name | [string](#string) |  | `OutputOnly` The Repository name. |
+| meta | [GithubRepositoryReference](#ddev.administration.v1alpha1.GithubRepositoryReference) | repeated | `OutputOnly` The Repository metadata. |
 
 
 
 
 
- 
+
+<a name="ddev.administration.v1alpha1.GithubIntegrationRequest"></a>
+
+### GithubIntegrationRequest
 
 
-<a name="ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope"></a>
 
-### ListWorkspaceRequest.ListWorkspaceScope
-Defines the scope of the request.  If the scope is set to ADMIN the response will contain only workspaces where the provided token user is an administrator.
-If the request is set to DEVELOPER the response will contain any workspace where the provided token user is an administrator or a developer.
-
-| Name | Number | Description |
-| ---- | ------ | ----------- |
-| DEVELOPER | 0 |  |
-| ADMIN | 1 |  |
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| installationID | [int64](#int64) |  | `Required` Installation ID. |
+| githubAppID | [int64](#int64) |  | `Required` Github App ID. |
+| githubAppSlug | [string](#string) |  | `Optional` Github App Slug. |
 
 
- 
 
- 
 
- 
+
+
+<a name="ddev.administration.v1alpha1.GithubIntegrationResponse"></a>
+
+### GithubIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| installationID | [int64](#int64) |  | `Required` Installation ID. |
+| githubAppID | [int64](#int64) |  | `Required` Github App ID. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubRepositoryName"></a>
+
+### GithubRepositoryName
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `OutputOnly` The Repository ID. |
+| name | [string](#string) |  | `OutputOnly` The Repository name. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubRepositoryOwner"></a>
+
+### GithubRepositoryOwner
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | `OutputOnly` The Owner name. |
+| repositories | [GithubRepositoryName](#ddev.administration.v1alpha1.GithubRepositoryName) | repeated | `OutputOnly` List of Repository Names for this Owner. |
+| installationID | [string](#string) |  | `OutputOnly` The Installation ID of this Owner&#39;s GitHub App installation. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubRepositoryReference"></a>
+
+### GithubRepositoryReference
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| sha | [string](#string) |  | `OutputOnly` Reference commit sha. |
+| branch | [string](#string) |  |  |
+| tag | [string](#string) |  |  |
+| pullrequest | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListGithubRepositoriesRequest"></a>
+
+### ListGithubRepositoriesRequest
 
 
 
@@ -973,14 +965,19 @@ If the request is set to DEVELOPER the response will contain any workspace where
 
 ### DeleteGitlabIntegrationResponse
 
+ 
 
+ 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | integration | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) |  | `OutputOnly` The deleted GitlabIntegration resource. |
 
 
+<a name="live/administration/v1alpha1/workspace.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
 
+## live/administration/v1alpha1/workspace.proto
 
 
 
@@ -1134,6 +1131,9 @@ If the request is set to DEVELOPER the response will contain any workspace where
 
 
 
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
 
 
 

--- a/doc/api/administration-api.md
+++ b/doc/api/administration-api.md
@@ -717,192 +717,200 @@ Describes a set of access policies for a user
 <a name="live/administration/v1alpha1/workspace.proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## live/administration/v1alpha1/githubintegration.proto
+## live/administration/v1alpha1/workspace.proto
 
 
 
-<a name="ddev.administration.v1alpha1.CreateGithubIntegrationRequest"></a>
+<a name="ddev.administration.v1alpha1.AddWorkspaceAdminRequest"></a>
 
-### CreateGithubIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The new GithubIntegration resource |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.CreateGithubIntegrationResponse"></a>
-
-### CreateGithubIntegrationResponse
+### AddWorkspaceAdminRequest
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The new GithubIntegration resource |
+| workspace | [string](#string) |  | `Required` The name of the workspace to add this administrator to. |
+| email | [string](#string) |  | `Required` The email of the workspace administrator |
 
 
 
 
 
 
-<a name="ddev.administration.v1alpha1.DeleteGithubIntegrationRequest"></a>
+<a name="ddev.administration.v1alpha1.AddWorkspaceAdminResponse"></a>
 
-### DeleteGithubIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The deleted GithubIntegration resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteGithubIntegrationResponse"></a>
-
-### DeleteGithubIntegrationResponse
+### AddWorkspaceAdminResponse
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The deleted GithubIntegration resource. |
+| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
 
 
 
 
 
 
-<a name="ddev.administration.v1alpha1.GetRepositoryMetadataRequest"></a>
+<a name="ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest"></a>
 
-### GetRepositoryMetadataRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `Required` The Repository ID. |
-| owner | [string](#string) |  | `Optional` The Repository owner. |
-| name | [string](#string) |  | `Optional` The Repository name. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GetRepositoryMetadataResponse"></a>
-
-### GetRepositoryMetadataResponse
+### AddWorkspaceDeveloperRequest
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `OutputOnly` The Repository ID. |
-| owner | [string](#string) |  | `OutputOnly` The Repository owner. |
-| name | [string](#string) |  | `OutputOnly` The Repository name. |
-| meta | [GithubRepositoryReference](#ddev.administration.v1alpha1.GithubRepositoryReference) | repeated | `OutputOnly` The Repository metadata. |
+| workspace | [string](#string) |  | `Required` The name of the workspace to add this developer to. |
+| email | [string](#string) |  | `Required` The email of the workspace developer. |
 
 
 
 
 
 
-<a name="ddev.administration.v1alpha1.GithubIntegrationRequest"></a>
+<a name="ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse"></a>
 
-### GithubIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| installationID | [int64](#int64) |  | `Required` Installation ID. |
-| githubAppID | [int64](#int64) |  | `Required` Github App ID. |
-| githubAppSlug | [string](#string) |  | `Optional` Github App Slug. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubIntegrationResponse"></a>
-
-### GithubIntegrationResponse
+### AddWorkspaceDeveloperResponse
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| installationID | [int64](#int64) |  | `Required` Installation ID. |
-| githubAppID | [int64](#int64) |  | `Required` Github App ID. |
+| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
 
 
 
 
 
 
-<a name="ddev.administration.v1alpha1.GithubRepositoryName"></a>
+<a name="ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest"></a>
 
-### GithubRepositoryName
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `OutputOnly` The Repository ID. |
-| name | [string](#string) |  | `OutputOnly` The Repository name. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubRepositoryOwner"></a>
-
-### GithubRepositoryOwner
+### DeleteWorkspaceAdminRequest
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | `OutputOnly` The Owner name. |
-| repositories | [GithubRepositoryName](#ddev.administration.v1alpha1.GithubRepositoryName) | repeated | `OutputOnly` List of Repository Names for this Owner. |
-| installationID | [string](#string) |  | `OutputOnly` The Installation ID of this Owner&#39;s GitHub App installation. |
+| workspace | [string](#string) |  | `Required` The name of the workspace to remove this administrator from. |
+| email | [string](#string) |  | `Required` The email of the workspace administrator. |
 
 
 
 
 
 
-<a name="ddev.administration.v1alpha1.GithubRepositoryReference"></a>
+<a name="ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse"></a>
 
-### GithubRepositoryReference
+### DeleteWorkspaceAdminResponse
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| sha | [string](#string) |  | `OutputOnly` Reference commit sha. |
-| branch | [string](#string) |  |  |
-| tag | [string](#string) |  |  |
-| pullrequest | [string](#string) |  |  |
+| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
 
 
 
 
 
 
-<a name="ddev.administration.v1alpha1.ListGithubRepositoriesRequest"></a>
+<a name="ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest"></a>
 
-### ListGithubRepositoriesRequest
+### DeleteWorkspaceDeveloperRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [string](#string) |  | `Required` The name of the workspace to remove this developer from. |
+| email | [string](#string) |  | `Required` The email of the workspace developer. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse"></a>
+
+### DeleteWorkspaceDeveloperResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListWorkspaceRequest"></a>
+
+### ListWorkspaceRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| Scope | [ListWorkspaceRequest.ListWorkspaceScope](#ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope) |  | `Optional` The scope of the list request. Defaults to `ListWorkspaceScope.DEVELOPER`. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListWorkspaceResponse"></a>
+
+### ListWorkspaceResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspaces | [Workspace](#ddev.administration.v1alpha1.Workspace) | repeated | `OutputOnly` - A workspace for the current user |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.Workspace"></a>
+
+### Workspace
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | `OutputOnly` Workspace Name. |
+| admins | [string](#string) | repeated | `OutputOnly` Administrators of the workspace |
+| developers | [string](#string) | repeated | `OutputOnly` Developers in the workspace |
+
+
+
+
+
+ 
+
+
+<a name="ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope"></a>
+
+### ListWorkspaceRequest.ListWorkspaceScope
+Defines the scope of the request.  If the scope is set to ADMIN the response will contain only workspaces where the provided token user is an administrator.
+If the request is set to DEVELOPER the response will contain any workspace where the provided token user is an administrator or a developer.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| DEVELOPER | 0 |  |
+| ADMIN | 1 |  |
+
+
+ 
+
+ 
+
+ 
 
 
 
@@ -965,19 +973,14 @@ Describes a set of access policies for a user
 
 ### DeleteGitlabIntegrationResponse
 
- 
 
- 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | integration | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) |  | `OutputOnly` The deleted GitlabIntegration resource. |
 
 
-<a name="live/administration/v1alpha1/workspace.proto"></a>
-<p align="right"><a href="#top">Top</a></p>
 
-## live/administration/v1alpha1/workspace.proto
 
 
 
@@ -1131,9 +1134,6 @@ Describes a set of access policies for a user
 
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
 
 
 

--- a/doc/api/site-api.md
+++ b/doc/api/site-api.md
@@ -818,6 +818,7 @@ Cron manages if and when the CMS cron executes
 | type | [SiteType](#ddev.sites.v1alpha1.SiteType) |  | The type of the CMS used for the site |
 | urls | [string](#string) | repeated | The URLs for the site |
 | status | [SiteStatus](#ddev.sites.v1alpha1.SiteStatus) |  | `Optional` A set of different status descriptions for a site |
+| attributes | [Site.Attributes](#ddev.sites.v1alpha1.Site.Attributes) |  | `Optional` Mutable attributes for a site. |
 | version | [string](#string) |  | `Optional` The version of the CMS used for the site |
 | composerInstall | [bool](#bool) |  | `Optional` Whether to run composer install when creating the site image |
 | composerArgs | [string](#string) | repeated | `Optional` If `composerInstall` is set, use this flags to specify which args are passed to composer install |

--- a/doc/api/site-api.md
+++ b/doc/api/site-api.md
@@ -3,26 +3,6 @@
 
 ## Table of Contents
 
-- [live/sites/v1alpha1/metadata.proto](#live/sites/v1alpha1/metadata.proto)
-    - [Metadata](#ddev.sites.v1alpha1.Metadata)
-    - [Metadata.LabelsEntry](#ddev.sites.v1alpha1.Metadata.LabelsEntry)
-  
-- [live/sites/v1alpha1/database.proto](#live/sites/v1alpha1/database.proto)
-    - [BackupDatabaseRequest](#ddev.sites.v1alpha1.BackupDatabaseRequest)
-    - [BackupDatabaseResponse](#ddev.sites.v1alpha1.BackupDatabaseResponse)
-    - [DatabaseBackup](#ddev.sites.v1alpha1.DatabaseBackup)
-    - [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata)
-    - [ListDatabaseBackupsRequest](#ddev.sites.v1alpha1.ListDatabaseBackupsRequest)
-    - [ListDatabaseBackupsResponse](#ddev.sites.v1alpha1.ListDatabaseBackupsResponse)
-    - [PullDatabaseBackupRequest](#ddev.sites.v1alpha1.PullDatabaseBackupRequest)
-    - [PullDatabaseBackupResponse](#ddev.sites.v1alpha1.PullDatabaseBackupResponse)
-    - [PushDatabaseBackupRequest](#ddev.sites.v1alpha1.PushDatabaseBackupRequest)
-    - [PushDatabaseBackupResponse](#ddev.sites.v1alpha1.PushDatabaseBackupResponse)
-    - [RestoreDatabaseRequest](#ddev.sites.v1alpha1.RestoreDatabaseRequest)
-    - [RestoreDatabaseResponse](#ddev.sites.v1alpha1.RestoreDatabaseResponse)
-  
-    - [BackupState](#ddev.sites.v1alpha1.BackupState)
-  
 - [live/sites/v1alpha1/file.proto](#live/sites/v1alpha1/file.proto)
     - [BackupFilesRequest](#ddev.sites.v1alpha1.BackupFilesRequest)
     - [BackupFilesResponse](#ddev.sites.v1alpha1.BackupFilesResponse)
@@ -40,9 +20,6 @@
     - [RestoreFilesRequest](#ddev.sites.v1alpha1.RestoreFilesRequest)
     - [RestoreFilesResponse](#ddev.sites.v1alpha1.RestoreFilesResponse)
   
-- [live/sites/v1alpha1/service.proto](#live/sites/v1alpha1/service.proto)
-    - [Sites](#ddev.sites.v1alpha1.Sites)
-  
 - [live/sites/v1alpha1/site.proto](#live/sites/v1alpha1/site.proto)
     - [AccessLogsRequest](#ddev.sites.v1alpha1.AccessLogsRequest)
     - [AccessLogsResponse](#ddev.sites.v1alpha1.AccessLogsResponse)
@@ -52,6 +29,7 @@
     - [CloneRequest](#ddev.sites.v1alpha1.CloneRequest)
     - [CloneResponse](#ddev.sites.v1alpha1.CloneResponse)
     - [CreateSiteRequest](#ddev.sites.v1alpha1.CreateSiteRequest)
+    - [CreateSiteRequest.TagsEntry](#ddev.sites.v1alpha1.CreateSiteRequest.TagsEntry)
     - [CreateSiteResponse](#ddev.sites.v1alpha1.CreateSiteResponse)
     - [Cron](#ddev.sites.v1alpha1.Cron)
     - [DeleteCloneRequest](#ddev.sites.v1alpha1.DeleteCloneRequest)
@@ -73,284 +51,44 @@
     - [MysqlLogsRequest](#ddev.sites.v1alpha1.MysqlLogsRequest)
     - [MysqlLogsResponse](#ddev.sites.v1alpha1.MysqlLogsResponse)
     - [Site](#ddev.sites.v1alpha1.Site)
+    - [Site.Attributes](#ddev.sites.v1alpha1.Site.Attributes)
+    - [Site.Attributes.TagsEntry](#ddev.sites.v1alpha1.Site.Attributes.TagsEntry)
     - [SiteExecRequest](#ddev.sites.v1alpha1.SiteExecRequest)
     - [SiteExecResponse](#ddev.sites.v1alpha1.SiteExecResponse)
     - [SiteLogsRequest](#ddev.sites.v1alpha1.SiteLogsRequest)
     - [SiteLogsResponse](#ddev.sites.v1alpha1.SiteLogsResponse)
     - [SiteStatus](#ddev.sites.v1alpha1.SiteStatus)
     - [UpdateSiteRequest](#ddev.sites.v1alpha1.UpdateSiteRequest)
+    - [UpdateSiteRequest.TagsEntry](#ddev.sites.v1alpha1.UpdateSiteRequest.TagsEntry)
     - [UpdateSiteResponse](#ddev.sites.v1alpha1.UpdateSiteResponse)
   
     - [CloneOperationState](#ddev.sites.v1alpha1.CloneOperationState)
     - [SiteType](#ddev.sites.v1alpha1.SiteType)
   
+- [live/sites/v1alpha1/database.proto](#live/sites/v1alpha1/database.proto)
+    - [BackupDatabaseRequest](#ddev.sites.v1alpha1.BackupDatabaseRequest)
+    - [BackupDatabaseResponse](#ddev.sites.v1alpha1.BackupDatabaseResponse)
+    - [DatabaseBackup](#ddev.sites.v1alpha1.DatabaseBackup)
+    - [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata)
+    - [ListDatabaseBackupsRequest](#ddev.sites.v1alpha1.ListDatabaseBackupsRequest)
+    - [ListDatabaseBackupsResponse](#ddev.sites.v1alpha1.ListDatabaseBackupsResponse)
+    - [PullDatabaseBackupRequest](#ddev.sites.v1alpha1.PullDatabaseBackupRequest)
+    - [PullDatabaseBackupResponse](#ddev.sites.v1alpha1.PullDatabaseBackupResponse)
+    - [PushDatabaseBackupRequest](#ddev.sites.v1alpha1.PushDatabaseBackupRequest)
+    - [PushDatabaseBackupResponse](#ddev.sites.v1alpha1.PushDatabaseBackupResponse)
+    - [RestoreDatabaseRequest](#ddev.sites.v1alpha1.RestoreDatabaseRequest)
+    - [RestoreDatabaseResponse](#ddev.sites.v1alpha1.RestoreDatabaseResponse)
+  
+    - [BackupState](#ddev.sites.v1alpha1.BackupState)
+  
+- [live/sites/v1alpha1/metadata.proto](#live/sites/v1alpha1/metadata.proto)
+    - [Metadata](#ddev.sites.v1alpha1.Metadata)
+    - [Metadata.LabelsEntry](#ddev.sites.v1alpha1.Metadata.LabelsEntry)
+  
+- [live/sites/v1alpha1/service.proto](#live/sites/v1alpha1/service.proto)
+    - [Sites](#ddev.sites.v1alpha1.Sites)
+  
 - [Scalar Value Types](#scalar-value-types)
-
-
-
-<a name="live/sites/v1alpha1/metadata.proto"></a>
-<p align="right"><a href="#top">Top</a></p>
-
-## live/sites/v1alpha1/metadata.proto
-
-
-
-<a name="ddev.sites.v1alpha1.Metadata"></a>
-
-### Metadata
-Generic metadata about the object.
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| labels | [Metadata.LabelsEntry](#ddev.sites.v1alpha1.Metadata.LabelsEntry) | repeated | A map of labels set on the object |
-| created | [int64](#int64) |  | `OutputOnly` A unix timestamp which expresses the time in which this object was initially created. A zero value indicates that the timestamp has not been set. |
-| updated | [int64](#int64) |  | `OutputOnly` A unix timestamp which expresses the time in which this object was last updated. A zero value indicates that the timestamp has not been set. |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.Metadata.LabelsEntry"></a>
-
-### Metadata.LabelsEntry
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [string](#string) |  |  |
-| value | [string](#string) |  |  |
-
-
-
-
-
- 
-
- 
-
- 
-
- 
-
-
-
-<a name="live/sites/v1alpha1/database.proto"></a>
-<p align="right"><a href="#top">Top</a></p>
-
-## live/sites/v1alpha1/database.proto
-
-
-
-<a name="ddev.sites.v1alpha1.BackupDatabaseRequest"></a>
-
-### BackupDatabaseRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| site | [string](#string) |  | `Required` The name of the site to backup. |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.BackupDatabaseResponse"></a>
-
-### BackupDatabaseResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| backup | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) |  | The state of the backup |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.DatabaseBackup"></a>
-
-### DatabaseBackup
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| metadata | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) |  | Metadata information about this backup |
-| content | [bytes](#bytes) |  | The raw bytes the the content. Supported MIME Types: `gz` |
-| CRC32c | [string](#string) |  | `Optional` CRC32c checksum of the data, as described in RFC 4960, Appendix B; encoded using base64 in big-endian byte order. In the event of streaming requests the CRC32c shall represent the checksum of the entire file. If provided a checksum mismatch will result in an error on the receiver. |
-| MD5 | [string](#string) |  | `Optional` MD5 hash of the data; encoded using base64. In the event of streaming requests the MD5 shall represent the checksum of the entire file. If provided a checksum mismatch will result in an error on the receiver. |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.DatabaseBackupMetadata"></a>
-
-### DatabaseBackupMetadata
-The backup object
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | The name of the backup |
-| databaseReference | [string](#string) |  | The database this backup references |
-| created | [int64](#int64) |  | `OutputOnly` The unix timestamp in which this backup was taken |
-| state | [BackupState](#ddev.sites.v1alpha1.BackupState) |  | `OutputOnly` The state of this backup |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.ListDatabaseBackupsRequest"></a>
-
-### ListDatabaseBackupsRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| site | [string](#string) |  | `Required` The name of the site |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.ListDatabaseBackupsResponse"></a>
-
-### ListDatabaseBackupsResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| backup | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) | repeated | `OutputOnly` The metadata for all backup objects. |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.PullDatabaseBackupRequest"></a>
-
-### PullDatabaseBackupRequest
-Pull database pulls the state of a specified database backup
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| backup | [string](#string) |  | `Required` The name of the backup to pull. |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.PullDatabaseBackupResponse"></a>
-
-### PullDatabaseBackupResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| backup | [DatabaseBackup](#ddev.sites.v1alpha1.DatabaseBackup) |  | `OutputOnly` The backup object |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.PushDatabaseBackupRequest"></a>
-
-### PushDatabaseBackupRequest
-Push a single database to a site
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| site | [string](#string) |  | `Required` The name of the site to push to. |
-| backup | [DatabaseBackup](#ddev.sites.v1alpha1.DatabaseBackup) |  | The backup object |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.PushDatabaseBackupResponse"></a>
-
-### PushDatabaseBackupResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| backup | [string](#string) |  | The name of the restorable backup resource |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.RestoreDatabaseRequest"></a>
-
-### RestoreDatabaseRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| site | [string](#string) |  | `Required` The name of the site to restore. |
-| backup | [string](#string) |  | `Required` The name of the backup to restore the site to. |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.RestoreDatabaseResponse"></a>
-
-### RestoreDatabaseResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| backup | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) |  | The state of the backup |
-
-
-
-
-
- 
-
-
-<a name="ddev.sites.v1alpha1.BackupState"></a>
-
-### BackupState
-
-
-| Name | Number | Description |
-| ---- | ------ | ----------- |
-| CREATED | 0 |  |
-| FINISHED | 1 |  |
-| DELETED | 2 |  |
-
-
- 
-
- 
-
- 
 
 
 
@@ -605,66 +343,6 @@ TODO
 
 
 
-<a name="live/sites/v1alpha1/service.proto"></a>
-<p align="right"><a href="#top">Top</a></p>
-
-## live/sites/v1alpha1/service.proto
-
-
- 
-
- 
-
- 
-
-
-<a name="ddev.sites.v1alpha1.Sites"></a>
-
-### Sites
-The Sites service provides site level functions inside a users ddev-live workspace.
-To access the sites service consumers will have to initialize an authenticated client.  This requires
-several metadata to be passed to the client.
-
-`x-auth-token` which is a authentication token for the call.  This will be required to be a temporary token issued by the BillingAPI.
-
-`x-ddev-workspace` which is the workspace for all procedures.  For example a client request `ListSites` will list all sites in the workspace whose value is derived from the key `x-ddev-workspace`.
-
-| Method Name | Request Type | Response Type | Description |
-| ----------- | ------------ | ------------- | ------------|
-| CreateSite | [CreateSiteRequest](#ddev.sites.v1alpha1.CreateSiteRequest) | [CreateSiteResponse](#ddev.sites.v1alpha1.CreateSiteResponse) | CreateSite creates one of the supported site types |
-| GetSite | [GetSiteRequest](#ddev.sites.v1alpha1.GetSiteRequest) | [GetSiteResponse](#ddev.sites.v1alpha1.GetSiteResponse) | GetSite returns the state of a site by name |
-| ListSites | [ListSiteRequest](#ddev.sites.v1alpha1.ListSiteRequest) | [ListSiteResponse](#ddev.sites.v1alpha1.ListSiteResponse) | ListSites returns all sites within a workspace |
-| UpdateSite | [UpdateSiteRequest](#ddev.sites.v1alpha1.UpdateSiteRequest) | [UpdateSiteResponse](#ddev.sites.v1alpha1.UpdateSiteResponse) |  |
-| DeleteSite | [DeleteSiteRequest](#ddev.sites.v1alpha1.DeleteSiteRequest) | [DeleteSiteResponse](#ddev.sites.v1alpha1.DeleteSiteResponse) |  |
-| SiteLogStream | [SiteLogsRequest](#ddev.sites.v1alpha1.SiteLogsRequest) | [SiteLogsResponse](#ddev.sites.v1alpha1.SiteLogsResponse) stream | SiteLogStream returns a stream of logs for a site |
-| AccessLogStream | [AccessLogsRequest](#ddev.sites.v1alpha1.AccessLogsRequest) | [AccessLogsResponse](#ddev.sites.v1alpha1.AccessLogsResponse) stream | AccessLogStream returns a stream of access logs for a site |
-| MysqlLogStream | [MysqlLogsRequest](#ddev.sites.v1alpha1.MysqlLogsRequest) | [MysqlLogsResponse](#ddev.sites.v1alpha1.MysqlLogsResponse) stream | MysqlLogStream returns a stream of access logs for a site |
-| BuildLogStream | [BuildLogsRequest](#ddev.sites.v1alpha1.BuildLogsRequest) | [BuildLogsResponse](#ddev.sites.v1alpha1.BuildLogsResponse) stream | BuildLogStream returns a stream of build logs for a site |
-| SiteExecStream | [SiteExecRequest](#ddev.sites.v1alpha1.SiteExecRequest) stream | [SiteExecResponse](#ddev.sites.v1alpha1.SiteExecResponse) stream | SiteExecStream allows for the streaming execution of commands inside a site container |
-| CloneSite | [CloneRequest](#ddev.sites.v1alpha1.CloneRequest) | [CloneResponse](#ddev.sites.v1alpha1.CloneResponse) | CloneSite creates a clone of already existing site |
-| DescribeClone | [DescribeCloneRequest](#ddev.sites.v1alpha1.DescribeCloneRequest) | [DescribeCloneResponse](#ddev.sites.v1alpha1.DescribeCloneResponse) | DescribeClone describes the status of an in progress clone operation |
-| ListCloneSiteOperations | [ListCloneSiteOperationsRequest](#ddev.sites.v1alpha1.ListCloneSiteOperationsRequest) | [ListCloneSiteOperationsResponse](#ddev.sites.v1alpha1.ListCloneSiteOperationsResponse) | ListCloneSiteOperations lists all clone site operations |
-| ListClonesForSite | [ListClonesForSiteRequest](#ddev.sites.v1alpha1.ListClonesForSiteRequest) | [ListClonesForSiteResponse](#ddev.sites.v1alpha1.ListClonesForSiteResponse) | ListClonesForSite lists all clones for a particular origin site |
-| DeleteClone | [DeleteCloneRequest](#ddev.sites.v1alpha1.DeleteCloneRequest) | [DeleteCloneResponse](#ddev.sites.v1alpha1.DeleteCloneResponse) | DeleteClone removes a clone resource and any children of that clone resource |
-| BackupDatabase | [BackupDatabaseRequest](#ddev.sites.v1alpha1.BackupDatabaseRequest) | [BackupDatabaseResponse](#ddev.sites.v1alpha1.BackupDatabaseResponse) | BackupDatabase backs up a database associated with a site |
-| RestoreDatabase | [RestoreDatabaseRequest](#ddev.sites.v1alpha1.RestoreDatabaseRequest) | [RestoreDatabaseResponse](#ddev.sites.v1alpha1.RestoreDatabaseResponse) | RestoreDatabase restores a sites databases to a known backup |
-| PushDatabaseBackup | [PushDatabaseBackupRequest](#ddev.sites.v1alpha1.PushDatabaseBackupRequest) | [PushDatabaseBackupResponse](#ddev.sites.v1alpha1.PushDatabaseBackupResponse) | PushDatabaseBackup creates a new backup for a site and attempts to restore the site to that backup |
-| PushDatabaseBackupStream | [PushDatabaseBackupRequest](#ddev.sites.v1alpha1.PushDatabaseBackupRequest) stream | [PushDatabaseBackupResponse](#ddev.sites.v1alpha1.PushDatabaseBackupResponse) | PushDatabaseBackupStream creates a new backup for a site and attempts to restore the site to that backup |
-| PullDatabaseBackup | [PullDatabaseBackupRequest](#ddev.sites.v1alpha1.PullDatabaseBackupRequest) | [PullDatabaseBackupResponse](#ddev.sites.v1alpha1.PullDatabaseBackupResponse) | PullDatabase pulls down a database backup locally |
-| PullDatabaseBackupStream | [PullDatabaseBackupRequest](#ddev.sites.v1alpha1.PullDatabaseBackupRequest) | [PullDatabaseBackupResponse](#ddev.sites.v1alpha1.PullDatabaseBackupResponse) stream | PullDatabaseBackupStream pulls down a database backup locally |
-| ListDatabaseBackups | [ListDatabaseBackupsRequest](#ddev.sites.v1alpha1.ListDatabaseBackupsRequest) | [ListDatabaseBackupsResponse](#ddev.sites.v1alpha1.ListDatabaseBackupsResponse) | Lists database backups known for a provided site |
-| BackupFiles | [BackupFilesRequest](#ddev.sites.v1alpha1.BackupFilesRequest) | [BackupFilesResponse](#ddev.sites.v1alpha1.BackupFilesResponse) | BackupFiles backups up a currently running site environment to the staging area |
-| RestoreFiles | [RestoreFilesRequest](#ddev.sites.v1alpha1.RestoreFilesRequest) | [RestoreFilesResponse](#ddev.sites.v1alpha1.RestoreFilesResponse) | RestoreFiles restores the current staging area to a sites environment |
-| PushFileBackup | [PushFileBackupRequest](#ddev.sites.v1alpha1.PushFileBackupRequest) | [PushFileBackupResponse](#ddev.sites.v1alpha1.PushFileBackupResponse) | PushFile upload file assets to a sites backup staging area |
-| PushFileBackupStream | [PushFileBackupRequest](#ddev.sites.v1alpha1.PushFileBackupRequest) stream | [PushFileBackupResponse](#ddev.sites.v1alpha1.PushFileBackupResponse) | PushFileStream allows client side streaming of large files to a staged backup area |
-| PullFileBackupStream | [PullFileBackupRequest](#ddev.sites.v1alpha1.PullFileBackupRequest) | [PullFileBackupResponse](#ddev.sites.v1alpha1.PullFileBackupResponse) stream | PullFileStream streams currently staged file[s] from the server and pulls them down to a local source |
-| DescribeFileBackup | [DescribeFileBackupRequest](#ddev.sites.v1alpha1.DescribeFileBackupRequest) | [DescribeFileBackupResponse](#ddev.sites.v1alpha1.DescribeFileBackupResponse) | DescribeFiles returns the metadata for current files staged for a restore operation |
-| ListFileBackups | [ListFileBackupsRequest](#ddev.sites.v1alpha1.ListFileBackupsRequest) | [ListFileBackupsResponse](#ddev.sites.v1alpha1.ListFileBackupsResponse) | Lists file backups known for a provided site |
-
- 
-
-
-
 <a name="live/sites/v1alpha1/site.proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
@@ -797,6 +475,7 @@ several metadata to be passed to the client.
 | name | [string](#string) |  | `Required` The name of the site |
 | git | [GitRepository](#ddev.sites.v1alpha1.GitRepository) |  |  |
 | type | [SiteType](#ddev.sites.v1alpha1.SiteType) |  | `Required` The type of the CMS used for the site |
+| tags | [CreateSiteRequest.TagsEntry](#ddev.sites.v1alpha1.CreateSiteRequest.TagsEntry) | repeated | `Optional` Specify tags for a site |
 | version | [string](#string) |  | `Optional` The version of the CMS used for the site |
 | composerInstall | [bool](#bool) |  | `Optional` Whether to run composer install when creating the site image |
 | composerArgs | [string](#string) | repeated | `Optional` If `composerInstall` is set, use this flags to specify which args are passed to composer install |
@@ -804,6 +483,24 @@ several metadata to be passed to the client.
 | DocRoot | [string](#string) |  | `Optional` The relative docroot of the site, like &#39;docroot&#39; or &#39;htdocs&#39; or &#39;web&#39;. Defaults to empty, the repository&#39;s root directory. |
 | persistentPaths | [string](#string) | repeated | `Optional` A list of persistent mount paths relative to docroot (ex. content/uploads). |
 | ephemeralPaths | [string](#string) | repeated | `Optional` A list of ephemeral mount paths relative to docroot |
+| expiry | [string](#string) |  | `Optional` Specify the amount of time after which the site should be considered expired and garbage collected. Supported units are minutes, hours, days, with max of 5 days (e.g. 90m, 3h, 5d, etc.), empty string means no expiration. |
+| phpVersion | [string](#string) |  | `Optional` Specify the version of PHP for the site |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.CreateSiteRequest.TagsEntry"></a>
+
+### CreateSiteRequest.TagsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
 
 
 
@@ -1120,14 +817,48 @@ Cron manages if and when the CMS cron executes
 | git | [GitRepository](#ddev.sites.v1alpha1.GitRepository) |  |  |
 | type | [SiteType](#ddev.sites.v1alpha1.SiteType) |  | The type of the CMS used for the site |
 | urls | [string](#string) | repeated | The URLs for the site |
-| status | [SiteStatus](#ddev.sites.v1alpha1.SiteStatus) |  | A set of different status descriptions for a site |
-| version | [string](#string) |  | The version of the CMS used for the site |
-| composerInstall | [bool](#bool) |  | Whether to run composer install when creating the site image |
-| composerArgs | [string](#string) | repeated | If `composerInstall` is set, use this flags to specify which args are passed to composer install |
+| status | [SiteStatus](#ddev.sites.v1alpha1.SiteStatus) |  | `Optional` A set of different status descriptions for a site |
+| version | [string](#string) |  | `Optional` The version of the CMS used for the site |
+| composerInstall | [bool](#bool) |  | `Optional` Whether to run composer install when creating the site image |
+| composerArgs | [string](#string) | repeated | `Optional` If `composerInstall` is set, use this flags to specify which args are passed to composer install |
+| cron | [Cron](#ddev.sites.v1alpha1.Cron) |  | `Optional` `Deprecated` Please use Attributes.Cron |
+| DocRoot | [string](#string) |  | `Optional` The relative docroot of the site, like &#39;docroot&#39; or &#39;htdocs&#39; or &#39;web&#39;. Defaults to empty, the repository&#39;s root directory. |
+| persistentPaths | [string](#string) | repeated | `Optional` A list of persistent mount paths relative to docroot (ex. content/uploads). |
+| ephemeralPaths | [string](#string) | repeated | `Optional` A list of ephemeral mount paths relative to docroot |
+| phpVersion | [string](#string) |  | `Optional` Specify the version of PHP for the site |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.Site.Attributes"></a>
+
+### Site.Attributes
+NOTE: when beta, clean up attribute number
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| tags | [Site.Attributes.TagsEntry](#ddev.sites.v1alpha1.Site.Attributes.TagsEntry) | repeated | `Optional` Specify tags for a site |
 | cron | [Cron](#ddev.sites.v1alpha1.Cron) |  | `Optional` |
-| DocRoot | [string](#string) |  | The relative docroot of the site, like &#39;docroot&#39; or &#39;htdocs&#39; or &#39;web&#39;. Defaults to empty, the repository&#39;s root directory. |
-| persistentPaths | [string](#string) | repeated | A list of persistent mount paths relative to docroot (ex. content/uploads). |
-| ephemeralPaths | [string](#string) | repeated | A list of ephemeral mount paths relative to docroot |
+| expiry | [string](#string) |  | `Optional` Specify the amount of time after which the site should be considered expired and garbage collected. Supported units are minutes, hours, days, with max of 5 days (e.g. 90m, 3h, 5d, etc.), empty string means no expiration. |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.Site.Attributes.TagsEntry"></a>
+
+### Site.Attributes.TagsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
 
 
 
@@ -1219,7 +950,38 @@ Defines the overall status of a site.  A site is defined as health when all subs
 <a name="ddev.sites.v1alpha1.UpdateSiteRequest"></a>
 
 ### UpdateSiteRequest
-TODO
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| git | [GitRepository](#ddev.sites.v1alpha1.GitRepository) |  |  |
+| tags | [UpdateSiteRequest.TagsEntry](#ddev.sites.v1alpha1.UpdateSiteRequest.TagsEntry) | repeated | `Optional` Specify tags for a site |
+| version | [string](#string) |  | `Optional` The version of the CMS used for the site |
+| composerInstall | [bool](#bool) |  | `Optional` Whether to run composer install when creating the site image |
+| composerArgs | [string](#string) | repeated | `Optional` If `composerInstall` is set, use this flags to specify which args are passed to composer install |
+| cron | [Cron](#ddev.sites.v1alpha1.Cron) |  | `Optional` |
+| DocRoot | [string](#string) |  | `Optional` The relative docroot of the site, like &#39;docroot&#39; or &#39;htdocs&#39; or &#39;web&#39;. Defaults to empty, the repository&#39;s root directory. |
+| persistentPaths | [string](#string) | repeated | `Optional` A list of persistent mount paths relative to docroot (ex. content/uploads). |
+| ephemeralPaths | [string](#string) | repeated | `Optional` A list of ephemeral mount paths relative to docroot |
+| expiry | [string](#string) |  | `Optional` Specify the amount of time after which the site should be considered expired and garbage collected. Supported units are minutes, hours, days, with max of 5 days (e.g. 90m, 3h, 5d, etc.), empty string means no expiration. |
+| phpVersion | [string](#string) |  | `Optional` Specify the version of PHP for the site |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.UpdateSiteRequest.TagsEntry"></a>
+
+### UpdateSiteRequest.TagsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
 
 
 
@@ -1229,7 +991,12 @@ TODO
 <a name="ddev.sites.v1alpha1.UpdateSiteResponse"></a>
 
 ### UpdateSiteResponse
-TODO
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| site | [Site](#ddev.sites.v1alpha1.Site) |  | `OutputOnly` The requested site. |
 
 
 
@@ -1267,6 +1034,332 @@ TODO
  
 
  
+
+ 
+
+
+
+<a name="live/sites/v1alpha1/database.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## live/sites/v1alpha1/database.proto
+
+
+
+<a name="ddev.sites.v1alpha1.BackupDatabaseRequest"></a>
+
+### BackupDatabaseRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| site | [string](#string) |  | `Required` The name of the site to backup. |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.BackupDatabaseResponse"></a>
+
+### BackupDatabaseResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| backup | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) |  | The state of the backup |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.DatabaseBackup"></a>
+
+### DatabaseBackup
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| metadata | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) |  | Metadata information about this backup |
+| content | [bytes](#bytes) |  | The raw bytes the the content. Supported MIME Types: `gz` |
+| CRC32c | [string](#string) |  | `Optional` CRC32c checksum of the data, as described in RFC 4960, Appendix B; encoded using base64 in big-endian byte order. In the event of streaming requests the CRC32c shall represent the checksum of the entire file. If provided a checksum mismatch will result in an error on the receiver. |
+| MD5 | [string](#string) |  | `Optional` MD5 hash of the data; encoded using base64. In the event of streaming requests the MD5 shall represent the checksum of the entire file. If provided a checksum mismatch will result in an error on the receiver. |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.DatabaseBackupMetadata"></a>
+
+### DatabaseBackupMetadata
+The backup object
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | The name of the backup |
+| databaseReference | [string](#string) |  | The database this backup references |
+| created | [int64](#int64) |  | `OutputOnly` The unix timestamp in which this backup was taken |
+| state | [BackupState](#ddev.sites.v1alpha1.BackupState) |  | `OutputOnly` The state of this backup |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.ListDatabaseBackupsRequest"></a>
+
+### ListDatabaseBackupsRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| site | [string](#string) |  | `Required` The name of the site |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.ListDatabaseBackupsResponse"></a>
+
+### ListDatabaseBackupsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| backup | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) | repeated | `OutputOnly` The metadata for all backup objects. |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.PullDatabaseBackupRequest"></a>
+
+### PullDatabaseBackupRequest
+Pull database pulls the state of a specified database backup
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| backup | [string](#string) |  | `Required` The name of the backup to pull. |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.PullDatabaseBackupResponse"></a>
+
+### PullDatabaseBackupResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| backup | [DatabaseBackup](#ddev.sites.v1alpha1.DatabaseBackup) |  | `OutputOnly` The backup object |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.PushDatabaseBackupRequest"></a>
+
+### PushDatabaseBackupRequest
+Push a single database to a site
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| site | [string](#string) |  | `Required` The name of the site to push to. |
+| backup | [DatabaseBackup](#ddev.sites.v1alpha1.DatabaseBackup) |  | The backup object |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.PushDatabaseBackupResponse"></a>
+
+### PushDatabaseBackupResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| backup | [string](#string) |  | The name of the restorable backup resource |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.RestoreDatabaseRequest"></a>
+
+### RestoreDatabaseRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| site | [string](#string) |  | `Required` The name of the site to restore. |
+| backup | [string](#string) |  | `Required` The name of the backup to restore the site to. |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.RestoreDatabaseResponse"></a>
+
+### RestoreDatabaseResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| backup | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) |  | The state of the backup |
+
+
+
+
+
+ 
+
+
+<a name="ddev.sites.v1alpha1.BackupState"></a>
+
+### BackupState
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| CREATED | 0 |  |
+| FINISHED | 1 |  |
+| DELETED | 2 |  |
+
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="live/sites/v1alpha1/metadata.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## live/sites/v1alpha1/metadata.proto
+
+
+
+<a name="ddev.sites.v1alpha1.Metadata"></a>
+
+### Metadata
+Generic metadata about the object.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| labels | [Metadata.LabelsEntry](#ddev.sites.v1alpha1.Metadata.LabelsEntry) | repeated | A map of labels set on the object |
+| created | [int64](#int64) |  | `OutputOnly` A unix timestamp which expresses the time in which this object was initially created. A zero value indicates that the timestamp has not been set. |
+| updated | [int64](#int64) |  | `OutputOnly` A unix timestamp which expresses the time in which this object was last updated. A zero value indicates that the timestamp has not been set. |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.Metadata.LabelsEntry"></a>
+
+### Metadata.LabelsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="live/sites/v1alpha1/service.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## live/sites/v1alpha1/service.proto
+
+
+ 
+
+ 
+
+ 
+
+
+<a name="ddev.sites.v1alpha1.Sites"></a>
+
+### Sites
+The Sites service provides site level functions inside a users ddev-live workspace.
+To access the sites service consumers will have to initialize an authenticated client.  This requires
+several metadata to be passed to the client.
+
+`x-auth-token` which is a authentication token for the call.  This will be required to be a temporary token issued by the BillingAPI.
+
+`x-ddev-workspace` which is the workspace for all procedures.  For example a client request `ListSites` will list all sites in the workspace whose value is derived from the key `x-ddev-workspace`.
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| CreateSite | [CreateSiteRequest](#ddev.sites.v1alpha1.CreateSiteRequest) | [CreateSiteResponse](#ddev.sites.v1alpha1.CreateSiteResponse) | CreateSite creates one of the supported site types |
+| GetSite | [GetSiteRequest](#ddev.sites.v1alpha1.GetSiteRequest) | [GetSiteResponse](#ddev.sites.v1alpha1.GetSiteResponse) | GetSite returns the state of a site by name |
+| ListSites | [ListSiteRequest](#ddev.sites.v1alpha1.ListSiteRequest) | [ListSiteResponse](#ddev.sites.v1alpha1.ListSiteResponse) | ListSites returns all sites within a workspace |
+| UpdateSite | [UpdateSiteRequest](#ddev.sites.v1alpha1.UpdateSiteRequest) | [UpdateSiteResponse](#ddev.sites.v1alpha1.UpdateSiteResponse) |  |
+| DeleteSite | [DeleteSiteRequest](#ddev.sites.v1alpha1.DeleteSiteRequest) | [DeleteSiteResponse](#ddev.sites.v1alpha1.DeleteSiteResponse) |  |
+| SiteLogStream | [SiteLogsRequest](#ddev.sites.v1alpha1.SiteLogsRequest) | [SiteLogsResponse](#ddev.sites.v1alpha1.SiteLogsResponse) stream | SiteLogStream returns a stream of logs for a site |
+| AccessLogStream | [AccessLogsRequest](#ddev.sites.v1alpha1.AccessLogsRequest) | [AccessLogsResponse](#ddev.sites.v1alpha1.AccessLogsResponse) stream | AccessLogStream returns a stream of access logs for a site |
+| MysqlLogStream | [MysqlLogsRequest](#ddev.sites.v1alpha1.MysqlLogsRequest) | [MysqlLogsResponse](#ddev.sites.v1alpha1.MysqlLogsResponse) stream | MysqlLogStream returns a stream of access logs for a site |
+| BuildLogStream | [BuildLogsRequest](#ddev.sites.v1alpha1.BuildLogsRequest) | [BuildLogsResponse](#ddev.sites.v1alpha1.BuildLogsResponse) stream | BuildLogStream returns a stream of build logs for a site |
+| SiteExecStream | [SiteExecRequest](#ddev.sites.v1alpha1.SiteExecRequest) stream | [SiteExecResponse](#ddev.sites.v1alpha1.SiteExecResponse) stream | SiteExecStream allows for the streaming execution of commands inside a site container |
+| CloneSite | [CloneRequest](#ddev.sites.v1alpha1.CloneRequest) | [CloneResponse](#ddev.sites.v1alpha1.CloneResponse) | CloneSite creates a clone of already existing site |
+| DescribeClone | [DescribeCloneRequest](#ddev.sites.v1alpha1.DescribeCloneRequest) | [DescribeCloneResponse](#ddev.sites.v1alpha1.DescribeCloneResponse) | DescribeClone describes the status of an in progress clone operation |
+| ListCloneSiteOperations | [ListCloneSiteOperationsRequest](#ddev.sites.v1alpha1.ListCloneSiteOperationsRequest) | [ListCloneSiteOperationsResponse](#ddev.sites.v1alpha1.ListCloneSiteOperationsResponse) | ListCloneSiteOperations lists all clone site operations |
+| ListClonesForSite | [ListClonesForSiteRequest](#ddev.sites.v1alpha1.ListClonesForSiteRequest) | [ListClonesForSiteResponse](#ddev.sites.v1alpha1.ListClonesForSiteResponse) | ListClonesForSite lists all clones for a particular origin site |
+| DeleteClone | [DeleteCloneRequest](#ddev.sites.v1alpha1.DeleteCloneRequest) | [DeleteCloneResponse](#ddev.sites.v1alpha1.DeleteCloneResponse) | DeleteClone removes a clone resource and any children of that clone resource |
+| BackupDatabase | [BackupDatabaseRequest](#ddev.sites.v1alpha1.BackupDatabaseRequest) | [BackupDatabaseResponse](#ddev.sites.v1alpha1.BackupDatabaseResponse) | BackupDatabase backs up a database associated with a site |
+| RestoreDatabase | [RestoreDatabaseRequest](#ddev.sites.v1alpha1.RestoreDatabaseRequest) | [RestoreDatabaseResponse](#ddev.sites.v1alpha1.RestoreDatabaseResponse) | RestoreDatabase restores a sites databases to a known backup |
+| PushDatabaseBackup | [PushDatabaseBackupRequest](#ddev.sites.v1alpha1.PushDatabaseBackupRequest) | [PushDatabaseBackupResponse](#ddev.sites.v1alpha1.PushDatabaseBackupResponse) | PushDatabaseBackup creates a new backup for a site and attempts to restore the site to that backup |
+| PushDatabaseBackupStream | [PushDatabaseBackupRequest](#ddev.sites.v1alpha1.PushDatabaseBackupRequest) stream | [PushDatabaseBackupResponse](#ddev.sites.v1alpha1.PushDatabaseBackupResponse) | PushDatabaseBackupStream creates a new backup for a site and attempts to restore the site to that backup |
+| PullDatabaseBackup | [PullDatabaseBackupRequest](#ddev.sites.v1alpha1.PullDatabaseBackupRequest) | [PullDatabaseBackupResponse](#ddev.sites.v1alpha1.PullDatabaseBackupResponse) | PullDatabase pulls down a database backup locally |
+| PullDatabaseBackupStream | [PullDatabaseBackupRequest](#ddev.sites.v1alpha1.PullDatabaseBackupRequest) | [PullDatabaseBackupResponse](#ddev.sites.v1alpha1.PullDatabaseBackupResponse) stream | PullDatabaseBackupStream pulls down a database backup locally |
+| ListDatabaseBackups | [ListDatabaseBackupsRequest](#ddev.sites.v1alpha1.ListDatabaseBackupsRequest) | [ListDatabaseBackupsResponse](#ddev.sites.v1alpha1.ListDatabaseBackupsResponse) | Lists database backups known for a provided site |
+| BackupFiles | [BackupFilesRequest](#ddev.sites.v1alpha1.BackupFilesRequest) | [BackupFilesResponse](#ddev.sites.v1alpha1.BackupFilesResponse) | BackupFiles backups up a currently running site environment to the staging area |
+| RestoreFiles | [RestoreFilesRequest](#ddev.sites.v1alpha1.RestoreFilesRequest) | [RestoreFilesResponse](#ddev.sites.v1alpha1.RestoreFilesResponse) | RestoreFiles restores the current staging area to a sites environment |
+| PushFileBackup | [PushFileBackupRequest](#ddev.sites.v1alpha1.PushFileBackupRequest) | [PushFileBackupResponse](#ddev.sites.v1alpha1.PushFileBackupResponse) | PushFile upload file assets to a sites backup staging area |
+| PushFileBackupStream | [PushFileBackupRequest](#ddev.sites.v1alpha1.PushFileBackupRequest) stream | [PushFileBackupResponse](#ddev.sites.v1alpha1.PushFileBackupResponse) | PushFileStream allows client side streaming of large files to a staged backup area |
+| PullFileBackupStream | [PullFileBackupRequest](#ddev.sites.v1alpha1.PullFileBackupRequest) | [PullFileBackupResponse](#ddev.sites.v1alpha1.PullFileBackupResponse) stream | PullFileStream streams currently staged file[s] from the server and pulls them down to a local source |
+| DescribeFileBackup | [DescribeFileBackupRequest](#ddev.sites.v1alpha1.DescribeFileBackupRequest) | [DescribeFileBackupResponse](#ddev.sites.v1alpha1.DescribeFileBackupResponse) | DescribeFiles returns the metadata for current files staged for a restore operation |
+| ListFileBackups | [ListFileBackupsRequest](#ddev.sites.v1alpha1.ListFileBackupsRequest) | [ListFileBackupsResponse](#ddev.sites.v1alpha1.ListFileBackupsResponse) | Lists file backups known for a provided site |
 
  
 

--- a/doc/api/site-api.md
+++ b/doc/api/site-api.md
@@ -59,7 +59,6 @@
     - [SiteLogsResponse](#ddev.sites.v1alpha1.SiteLogsResponse)
     - [SiteStatus](#ddev.sites.v1alpha1.SiteStatus)
     - [UpdateSiteRequest](#ddev.sites.v1alpha1.UpdateSiteRequest)
-    - [UpdateSiteRequest.TagsEntry](#ddev.sites.v1alpha1.UpdateSiteRequest.TagsEntry)
     - [UpdateSiteResponse](#ddev.sites.v1alpha1.UpdateSiteResponse)
   
     - [CloneOperationState](#ddev.sites.v1alpha1.CloneOperationState)
@@ -956,34 +955,7 @@ Defines the overall status of a site.  A site is defined as health when all subs
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | `Required` The name of the site (needed to reference the existing site) |
-| git | [GitRepository](#ddev.sites.v1alpha1.GitRepository) |  |  |
-| tags | [UpdateSiteRequest.TagsEntry](#ddev.sites.v1alpha1.UpdateSiteRequest.TagsEntry) | repeated | `Optional` Specify tags for a site |
-| version | [string](#string) |  | `Optional` The version of the CMS used for the site |
-| composerInstall | [bool](#bool) |  | `Optional` Whether to run composer install when creating the site image |
-| composerArgs | [string](#string) | repeated | `Optional` If `composerInstall` is set, use this flags to specify which args are passed to composer install |
-| cron | [Cron](#ddev.sites.v1alpha1.Cron) |  | `Optional` |
-| DocRoot | [string](#string) |  | `Optional` The relative docroot of the site, like &#39;docroot&#39; or &#39;htdocs&#39; or &#39;web&#39;. Defaults to empty, the repository&#39;s root directory. |
-| persistentPaths | [string](#string) | repeated | `Optional` A list of persistent mount paths relative to docroot (ex. content/uploads). |
-| ephemeralPaths | [string](#string) | repeated | `Optional` A list of ephemeral mount paths relative to docroot |
-| expiry | [string](#string) |  | `Optional` Specify the amount of time after which the site should be considered expired and garbage collected. Supported units are minutes, hours, days, with max of 5 days (e.g. 90m, 3h, 5d, etc.), empty string means no expiration. |
-| phpVersion | [string](#string) |  | `Optional` Specify the version of PHP for the site |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.UpdateSiteRequest.TagsEntry"></a>
-
-### UpdateSiteRequest.TagsEntry
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [string](#string) |  |  |
-| value | [string](#string) |  |  |
+| site | [Site](#ddev.sites.v1alpha1.Site) |  | `Required` The requested site. |
 
 
 

--- a/doc/api/site-api.md
+++ b/doc/api/site-api.md
@@ -955,6 +955,7 @@ Defines the overall status of a site.  A site is defined as health when all subs
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | `Required` The name of the site (needed to reference the existing site) |
 | git | [GitRepository](#ddev.sites.v1alpha1.GitRepository) |  |  |
 | tags | [UpdateSiteRequest.TagsEntry](#ddev.sites.v1alpha1.UpdateSiteRequest.TagsEntry) | repeated | `Optional` Specify tags for a site |
 | version | [string](#string) |  | `Optional` The version of the CMS used for the site |

--- a/doc/api/site-api.md
+++ b/doc/api/site-api.md
@@ -59,7 +59,6 @@
     - [SiteLogsResponse](#ddev.sites.v1alpha1.SiteLogsResponse)
     - [SiteStatus](#ddev.sites.v1alpha1.SiteStatus)
     - [UpdateSiteRequest](#ddev.sites.v1alpha1.UpdateSiteRequest)
-    - [UpdateSiteRequest.TagsEntry](#ddev.sites.v1alpha1.UpdateSiteRequest.TagsEntry)
     - [UpdateSiteResponse](#ddev.sites.v1alpha1.UpdateSiteResponse)
   
     - [CloneOperationState](#ddev.sites.v1alpha1.CloneOperationState)
@@ -681,6 +680,7 @@ Cron manages if and when the CMS cron executes
 
 
 
+
 <a name="ddev.sites.v1alpha1.ListCloneSiteOperationsResponse"></a>
 
 ### ListCloneSiteOperationsResponse
@@ -735,6 +735,7 @@ Cron manages if and when the CMS cron executes
 
 
 
+
 <a name="ddev.sites.v1alpha1.ListSiteResponse"></a>
 
 ### ListSiteResponse
@@ -775,8 +776,6 @@ Cron manages if and when the CMS cron executes
 
 ### MysqlLogsRequest
 
-### Site.Attributes
-NOTE: when beta, clean up attribute number
 
 
 | Field | Type | Label | Description |
@@ -962,13 +961,11 @@ Defines the overall status of a site.  A site is defined as health when all subs
 
 
 
- 
 
 <a name="ddev.sites.v1alpha1.UpdateSiteResponse"></a>
 
 ### UpdateSiteResponse
 
-### CloneOperationState
 
 
 | Field | Type | Label | Description |
@@ -976,9 +973,7 @@ Defines the overall status of a site.  A site is defined as health when all subs
 | site | [Site](#ddev.sites.v1alpha1.Site) |  | `OutputOnly` The requested site. |
 
 
-<a name="ddev.sites.v1alpha1.SiteType"></a>
 
-### SiteType
 
 
  
@@ -995,7 +990,6 @@ Defines the overall status of a site.  A site is defined as health when all subs
 | CLONE_SUCCEEDED | 1 |  |
 | CLONE_FAILED | 2 |  |
 
-## live/sites/v1alpha1/database.proto
 
 
 <a name="ddev.sites.v1alpha1.SiteType"></a>
@@ -1061,12 +1055,6 @@ Defines the overall status of a site.  A site is defined as health when all subs
 ### DatabaseBackup
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | The name of the backup |
-| databaseReference | [string](#string) |  | The database this backup references |
-| created | [int64](#int64) |  | `OutputOnly` The unix timestamp in which this backup was taken |
-| state | [BackupState](#ddev.sites.v1alpha1.BackupState) |  | `OutputOnly` The state of this backup |
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
@@ -1117,8 +1105,6 @@ The backup object
 
 ### ListDatabaseBackupsResponse
 
-### PullDatabaseBackupRequest
-Pull database pulls the state of a specified database backup
 
 
 | Field | Type | Label | Description |
@@ -1149,8 +1135,6 @@ Pull database pulls the state of a specified database backup
 
 ### PullDatabaseBackupResponse
 
-### PushDatabaseBackupRequest
-Push a single database to a site
 
 
 | Field | Type | Label | Description |
@@ -1208,13 +1192,11 @@ Push a single database to a site
 
 
 
- 
 
 <a name="ddev.sites.v1alpha1.RestoreDatabaseResponse"></a>
 
 ### RestoreDatabaseResponse
 
-### BackupState
 
 
 | Field | Type | Label | Description |
@@ -1222,11 +1204,8 @@ Push a single database to a site
 | backup | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) |  | The state of the backup |
 
 
- 
 
- 
 
- 
 
  
 
@@ -1257,10 +1236,6 @@ Push a single database to a site
 ## live/sites/v1alpha1/metadata.proto
 
 
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [string](#string) |  |  |
-| value | [string](#string) |  |  |
 
 <a name="ddev.sites.v1alpha1.Metadata"></a>
 
@@ -1274,11 +1249,8 @@ Generic metadata about the object.
 | created | [int64](#int64) |  | `OutputOnly` A unix timestamp which expresses the time in which this object was initially created. A zero value indicates that the timestamp has not been set. |
 | updated | [int64](#int64) |  | `OutputOnly` A unix timestamp which expresses the time in which this object was last updated. A zero value indicates that the timestamp has not been set. |
 
- 
 
- 
 
- 
 
 
 
@@ -1286,7 +1258,6 @@ Generic metadata about the object.
 
 ### Metadata.LabelsEntry
 
-## live/sites/v1alpha1/service.proto
 
 
 | Field | Type | Label | Description |
@@ -1294,49 +1265,17 @@ Generic metadata about the object.
 | key | [string](#string) |  |  |
 | value | [string](#string) |  |  |
 
- 
 
 
 
-<a name="ddev.sites.v1alpha1.Sites"></a>
 
  
 
  
 
-`x-ddev-workspace` which is the workspace for all procedures.  For example a client request `ListSites` will list all sites in the workspace whose value is derived from the key `x-ddev-workspace`.
+ 
 
-| Method Name | Request Type | Response Type | Description |
-| ----------- | ------------ | ------------- | ------------|
-| CreateSite | [CreateSiteRequest](#ddev.sites.v1alpha1.CreateSiteRequest) | [CreateSiteResponse](#ddev.sites.v1alpha1.CreateSiteResponse) | CreateSite creates one of the supported site types |
-| GetSite | [GetSiteRequest](#ddev.sites.v1alpha1.GetSiteRequest) | [GetSiteResponse](#ddev.sites.v1alpha1.GetSiteResponse) | GetSite returns the state of a site by name |
-| ListSites | [ListSiteRequest](#ddev.sites.v1alpha1.ListSiteRequest) | [ListSiteResponse](#ddev.sites.v1alpha1.ListSiteResponse) | ListSites returns all sites within a workspace |
-| UpdateSite | [UpdateSiteRequest](#ddev.sites.v1alpha1.UpdateSiteRequest) | [UpdateSiteResponse](#ddev.sites.v1alpha1.UpdateSiteResponse) |  |
-| DeleteSite | [DeleteSiteRequest](#ddev.sites.v1alpha1.DeleteSiteRequest) | [DeleteSiteResponse](#ddev.sites.v1alpha1.DeleteSiteResponse) |  |
-| SiteLogStream | [SiteLogsRequest](#ddev.sites.v1alpha1.SiteLogsRequest) | [SiteLogsResponse](#ddev.sites.v1alpha1.SiteLogsResponse) stream | SiteLogStream returns a stream of logs for a site |
-| AccessLogStream | [AccessLogsRequest](#ddev.sites.v1alpha1.AccessLogsRequest) | [AccessLogsResponse](#ddev.sites.v1alpha1.AccessLogsResponse) stream | AccessLogStream returns a stream of access logs for a site |
-| MysqlLogStream | [MysqlLogsRequest](#ddev.sites.v1alpha1.MysqlLogsRequest) | [MysqlLogsResponse](#ddev.sites.v1alpha1.MysqlLogsResponse) stream | MysqlLogStream returns a stream of access logs for a site |
-| BuildLogStream | [BuildLogsRequest](#ddev.sites.v1alpha1.BuildLogsRequest) | [BuildLogsResponse](#ddev.sites.v1alpha1.BuildLogsResponse) stream | BuildLogStream returns a stream of build logs for a site |
-| SiteExecStream | [SiteExecRequest](#ddev.sites.v1alpha1.SiteExecRequest) stream | [SiteExecResponse](#ddev.sites.v1alpha1.SiteExecResponse) stream | SiteExecStream allows for the streaming execution of commands inside a site container |
-| CloneSite | [CloneRequest](#ddev.sites.v1alpha1.CloneRequest) | [CloneResponse](#ddev.sites.v1alpha1.CloneResponse) | CloneSite creates a clone of already existing site |
-| DescribeClone | [DescribeCloneRequest](#ddev.sites.v1alpha1.DescribeCloneRequest) | [DescribeCloneResponse](#ddev.sites.v1alpha1.DescribeCloneResponse) | DescribeClone describes the status of an in progress clone operation |
-| ListCloneSiteOperations | [ListCloneSiteOperationsRequest](#ddev.sites.v1alpha1.ListCloneSiteOperationsRequest) | [ListCloneSiteOperationsResponse](#ddev.sites.v1alpha1.ListCloneSiteOperationsResponse) | ListCloneSiteOperations lists all clone site operations |
-| ListClonesForSite | [ListClonesForSiteRequest](#ddev.sites.v1alpha1.ListClonesForSiteRequest) | [ListClonesForSiteResponse](#ddev.sites.v1alpha1.ListClonesForSiteResponse) | ListClonesForSite lists all clones for a particular origin site |
-| DeleteClone | [DeleteCloneRequest](#ddev.sites.v1alpha1.DeleteCloneRequest) | [DeleteCloneResponse](#ddev.sites.v1alpha1.DeleteCloneResponse) | DeleteClone removes a clone resource and any children of that clone resource |
-| BackupDatabase | [BackupDatabaseRequest](#ddev.sites.v1alpha1.BackupDatabaseRequest) | [BackupDatabaseResponse](#ddev.sites.v1alpha1.BackupDatabaseResponse) | BackupDatabase backs up a database associated with a site |
-| RestoreDatabase | [RestoreDatabaseRequest](#ddev.sites.v1alpha1.RestoreDatabaseRequest) | [RestoreDatabaseResponse](#ddev.sites.v1alpha1.RestoreDatabaseResponse) | RestoreDatabase restores a sites databases to a known backup |
-| PushDatabaseBackup | [PushDatabaseBackupRequest](#ddev.sites.v1alpha1.PushDatabaseBackupRequest) | [PushDatabaseBackupResponse](#ddev.sites.v1alpha1.PushDatabaseBackupResponse) | PushDatabaseBackup creates a new backup for a site and attempts to restore the site to that backup |
-| PushDatabaseBackupStream | [PushDatabaseBackupRequest](#ddev.sites.v1alpha1.PushDatabaseBackupRequest) stream | [PushDatabaseBackupResponse](#ddev.sites.v1alpha1.PushDatabaseBackupResponse) | PushDatabaseBackupStream creates a new backup for a site and attempts to restore the site to that backup |
-| PullDatabaseBackup | [PullDatabaseBackupRequest](#ddev.sites.v1alpha1.PullDatabaseBackupRequest) | [PullDatabaseBackupResponse](#ddev.sites.v1alpha1.PullDatabaseBackupResponse) | PullDatabase pulls down a database backup locally |
-| PullDatabaseBackupStream | [PullDatabaseBackupRequest](#ddev.sites.v1alpha1.PullDatabaseBackupRequest) | [PullDatabaseBackupResponse](#ddev.sites.v1alpha1.PullDatabaseBackupResponse) stream | PullDatabaseBackupStream pulls down a database backup locally |
-| ListDatabaseBackups | [ListDatabaseBackupsRequest](#ddev.sites.v1alpha1.ListDatabaseBackupsRequest) | [ListDatabaseBackupsResponse](#ddev.sites.v1alpha1.ListDatabaseBackupsResponse) | Lists database backups known for a provided site |
-| BackupFiles | [BackupFilesRequest](#ddev.sites.v1alpha1.BackupFilesRequest) | [BackupFilesResponse](#ddev.sites.v1alpha1.BackupFilesResponse) | BackupFiles backups up a currently running site environment to the staging area |
-| RestoreFiles | [RestoreFilesRequest](#ddev.sites.v1alpha1.RestoreFilesRequest) | [RestoreFilesResponse](#ddev.sites.v1alpha1.RestoreFilesResponse) | RestoreFiles restores the current staging area to a sites environment |
-| PushFileBackup | [PushFileBackupRequest](#ddev.sites.v1alpha1.PushFileBackupRequest) | [PushFileBackupResponse](#ddev.sites.v1alpha1.PushFileBackupResponse) | PushFile upload file assets to a sites backup staging area |
-| PushFileBackupStream | [PushFileBackupRequest](#ddev.sites.v1alpha1.PushFileBackupRequest) stream | [PushFileBackupResponse](#ddev.sites.v1alpha1.PushFileBackupResponse) | PushFileStream allows client side streaming of large files to a staged backup area |
-| PullFileBackupStream | [PullFileBackupRequest](#ddev.sites.v1alpha1.PullFileBackupRequest) | [PullFileBackupResponse](#ddev.sites.v1alpha1.PullFileBackupResponse) stream | PullFileStream streams currently staged file[s] from the server and pulls them down to a local source |
-| DescribeFileBackup | [DescribeFileBackupRequest](#ddev.sites.v1alpha1.DescribeFileBackupRequest) | [DescribeFileBackupResponse](#ddev.sites.v1alpha1.DescribeFileBackupResponse) | DescribeFiles returns the metadata for current files staged for a restore operation |
-| ListFileBackups | [ListFileBackupsRequest](#ddev.sites.v1alpha1.ListFileBackupsRequest) | [ListFileBackupsResponse](#ddev.sites.v1alpha1.ListFileBackupsResponse) | Lists file backups known for a provided site |
+ 
 
 
 

--- a/doc/api/site-api.md
+++ b/doc/api/site-api.md
@@ -59,6 +59,7 @@
     - [SiteLogsResponse](#ddev.sites.v1alpha1.SiteLogsResponse)
     - [SiteStatus](#ddev.sites.v1alpha1.SiteStatus)
     - [UpdateSiteRequest](#ddev.sites.v1alpha1.UpdateSiteRequest)
+    - [UpdateSiteRequest.TagsEntry](#ddev.sites.v1alpha1.UpdateSiteRequest.TagsEntry)
     - [UpdateSiteResponse](#ddev.sites.v1alpha1.UpdateSiteResponse)
   
     - [CloneOperationState](#ddev.sites.v1alpha1.CloneOperationState)
@@ -680,7 +681,6 @@ Cron manages if and when the CMS cron executes
 
 
 
-
 <a name="ddev.sites.v1alpha1.ListCloneSiteOperationsResponse"></a>
 
 ### ListCloneSiteOperationsResponse
@@ -735,7 +735,6 @@ Cron manages if and when the CMS cron executes
 
 
 
-
 <a name="ddev.sites.v1alpha1.ListSiteResponse"></a>
 
 ### ListSiteResponse
@@ -776,6 +775,8 @@ Cron manages if and when the CMS cron executes
 
 ### MysqlLogsRequest
 
+### Site.Attributes
+NOTE: when beta, clean up attribute number
 
 
 | Field | Type | Label | Description |
@@ -961,11 +962,13 @@ Defines the overall status of a site.  A site is defined as health when all subs
 
 
 
+ 
 
 <a name="ddev.sites.v1alpha1.UpdateSiteResponse"></a>
 
 ### UpdateSiteResponse
 
+### CloneOperationState
 
 
 | Field | Type | Label | Description |
@@ -973,7 +976,9 @@ Defines the overall status of a site.  A site is defined as health when all subs
 | site | [Site](#ddev.sites.v1alpha1.Site) |  | `OutputOnly` The requested site. |
 
 
+<a name="ddev.sites.v1alpha1.SiteType"></a>
 
+### SiteType
 
 
  
@@ -990,6 +995,7 @@ Defines the overall status of a site.  A site is defined as health when all subs
 | CLONE_SUCCEEDED | 1 |  |
 | CLONE_FAILED | 2 |  |
 
+## live/sites/v1alpha1/database.proto
 
 
 <a name="ddev.sites.v1alpha1.SiteType"></a>
@@ -1055,6 +1061,12 @@ Defines the overall status of a site.  A site is defined as health when all subs
 ### DatabaseBackup
 
 
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | The name of the backup |
+| databaseReference | [string](#string) |  | The database this backup references |
+| created | [int64](#int64) |  | `OutputOnly` The unix timestamp in which this backup was taken |
+| state | [BackupState](#ddev.sites.v1alpha1.BackupState) |  | `OutputOnly` The state of this backup |
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
@@ -1105,6 +1117,8 @@ The backup object
 
 ### ListDatabaseBackupsResponse
 
+### PullDatabaseBackupRequest
+Pull database pulls the state of a specified database backup
 
 
 | Field | Type | Label | Description |
@@ -1135,6 +1149,8 @@ Pull database pulls the state of a specified database backup
 
 ### PullDatabaseBackupResponse
 
+### PushDatabaseBackupRequest
+Push a single database to a site
 
 
 | Field | Type | Label | Description |
@@ -1192,11 +1208,13 @@ Push a single database to a site
 
 
 
+ 
 
 <a name="ddev.sites.v1alpha1.RestoreDatabaseResponse"></a>
 
 ### RestoreDatabaseResponse
 
+### BackupState
 
 
 | Field | Type | Label | Description |
@@ -1204,8 +1222,11 @@ Push a single database to a site
 | backup | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) |  | The state of the backup |
 
 
+ 
 
+ 
 
+ 
 
  
 
@@ -1236,6 +1257,10 @@ Push a single database to a site
 ## live/sites/v1alpha1/metadata.proto
 
 
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
 
 <a name="ddev.sites.v1alpha1.Metadata"></a>
 
@@ -1249,8 +1274,11 @@ Generic metadata about the object.
 | created | [int64](#int64) |  | `OutputOnly` A unix timestamp which expresses the time in which this object was initially created. A zero value indicates that the timestamp has not been set. |
 | updated | [int64](#int64) |  | `OutputOnly` A unix timestamp which expresses the time in which this object was last updated. A zero value indicates that the timestamp has not been set. |
 
+ 
 
+ 
 
+ 
 
 
 
@@ -1258,6 +1286,7 @@ Generic metadata about the object.
 
 ### Metadata.LabelsEntry
 
+## live/sites/v1alpha1/service.proto
 
 
 | Field | Type | Label | Description |
@@ -1265,17 +1294,49 @@ Generic metadata about the object.
 | key | [string](#string) |  |  |
 | value | [string](#string) |  |  |
 
+ 
 
 
 
+<a name="ddev.sites.v1alpha1.Sites"></a>
 
  
 
  
 
- 
+`x-ddev-workspace` which is the workspace for all procedures.  For example a client request `ListSites` will list all sites in the workspace whose value is derived from the key `x-ddev-workspace`.
 
- 
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| CreateSite | [CreateSiteRequest](#ddev.sites.v1alpha1.CreateSiteRequest) | [CreateSiteResponse](#ddev.sites.v1alpha1.CreateSiteResponse) | CreateSite creates one of the supported site types |
+| GetSite | [GetSiteRequest](#ddev.sites.v1alpha1.GetSiteRequest) | [GetSiteResponse](#ddev.sites.v1alpha1.GetSiteResponse) | GetSite returns the state of a site by name |
+| ListSites | [ListSiteRequest](#ddev.sites.v1alpha1.ListSiteRequest) | [ListSiteResponse](#ddev.sites.v1alpha1.ListSiteResponse) | ListSites returns all sites within a workspace |
+| UpdateSite | [UpdateSiteRequest](#ddev.sites.v1alpha1.UpdateSiteRequest) | [UpdateSiteResponse](#ddev.sites.v1alpha1.UpdateSiteResponse) |  |
+| DeleteSite | [DeleteSiteRequest](#ddev.sites.v1alpha1.DeleteSiteRequest) | [DeleteSiteResponse](#ddev.sites.v1alpha1.DeleteSiteResponse) |  |
+| SiteLogStream | [SiteLogsRequest](#ddev.sites.v1alpha1.SiteLogsRequest) | [SiteLogsResponse](#ddev.sites.v1alpha1.SiteLogsResponse) stream | SiteLogStream returns a stream of logs for a site |
+| AccessLogStream | [AccessLogsRequest](#ddev.sites.v1alpha1.AccessLogsRequest) | [AccessLogsResponse](#ddev.sites.v1alpha1.AccessLogsResponse) stream | AccessLogStream returns a stream of access logs for a site |
+| MysqlLogStream | [MysqlLogsRequest](#ddev.sites.v1alpha1.MysqlLogsRequest) | [MysqlLogsResponse](#ddev.sites.v1alpha1.MysqlLogsResponse) stream | MysqlLogStream returns a stream of access logs for a site |
+| BuildLogStream | [BuildLogsRequest](#ddev.sites.v1alpha1.BuildLogsRequest) | [BuildLogsResponse](#ddev.sites.v1alpha1.BuildLogsResponse) stream | BuildLogStream returns a stream of build logs for a site |
+| SiteExecStream | [SiteExecRequest](#ddev.sites.v1alpha1.SiteExecRequest) stream | [SiteExecResponse](#ddev.sites.v1alpha1.SiteExecResponse) stream | SiteExecStream allows for the streaming execution of commands inside a site container |
+| CloneSite | [CloneRequest](#ddev.sites.v1alpha1.CloneRequest) | [CloneResponse](#ddev.sites.v1alpha1.CloneResponse) | CloneSite creates a clone of already existing site |
+| DescribeClone | [DescribeCloneRequest](#ddev.sites.v1alpha1.DescribeCloneRequest) | [DescribeCloneResponse](#ddev.sites.v1alpha1.DescribeCloneResponse) | DescribeClone describes the status of an in progress clone operation |
+| ListCloneSiteOperations | [ListCloneSiteOperationsRequest](#ddev.sites.v1alpha1.ListCloneSiteOperationsRequest) | [ListCloneSiteOperationsResponse](#ddev.sites.v1alpha1.ListCloneSiteOperationsResponse) | ListCloneSiteOperations lists all clone site operations |
+| ListClonesForSite | [ListClonesForSiteRequest](#ddev.sites.v1alpha1.ListClonesForSiteRequest) | [ListClonesForSiteResponse](#ddev.sites.v1alpha1.ListClonesForSiteResponse) | ListClonesForSite lists all clones for a particular origin site |
+| DeleteClone | [DeleteCloneRequest](#ddev.sites.v1alpha1.DeleteCloneRequest) | [DeleteCloneResponse](#ddev.sites.v1alpha1.DeleteCloneResponse) | DeleteClone removes a clone resource and any children of that clone resource |
+| BackupDatabase | [BackupDatabaseRequest](#ddev.sites.v1alpha1.BackupDatabaseRequest) | [BackupDatabaseResponse](#ddev.sites.v1alpha1.BackupDatabaseResponse) | BackupDatabase backs up a database associated with a site |
+| RestoreDatabase | [RestoreDatabaseRequest](#ddev.sites.v1alpha1.RestoreDatabaseRequest) | [RestoreDatabaseResponse](#ddev.sites.v1alpha1.RestoreDatabaseResponse) | RestoreDatabase restores a sites databases to a known backup |
+| PushDatabaseBackup | [PushDatabaseBackupRequest](#ddev.sites.v1alpha1.PushDatabaseBackupRequest) | [PushDatabaseBackupResponse](#ddev.sites.v1alpha1.PushDatabaseBackupResponse) | PushDatabaseBackup creates a new backup for a site and attempts to restore the site to that backup |
+| PushDatabaseBackupStream | [PushDatabaseBackupRequest](#ddev.sites.v1alpha1.PushDatabaseBackupRequest) stream | [PushDatabaseBackupResponse](#ddev.sites.v1alpha1.PushDatabaseBackupResponse) | PushDatabaseBackupStream creates a new backup for a site and attempts to restore the site to that backup |
+| PullDatabaseBackup | [PullDatabaseBackupRequest](#ddev.sites.v1alpha1.PullDatabaseBackupRequest) | [PullDatabaseBackupResponse](#ddev.sites.v1alpha1.PullDatabaseBackupResponse) | PullDatabase pulls down a database backup locally |
+| PullDatabaseBackupStream | [PullDatabaseBackupRequest](#ddev.sites.v1alpha1.PullDatabaseBackupRequest) | [PullDatabaseBackupResponse](#ddev.sites.v1alpha1.PullDatabaseBackupResponse) stream | PullDatabaseBackupStream pulls down a database backup locally |
+| ListDatabaseBackups | [ListDatabaseBackupsRequest](#ddev.sites.v1alpha1.ListDatabaseBackupsRequest) | [ListDatabaseBackupsResponse](#ddev.sites.v1alpha1.ListDatabaseBackupsResponse) | Lists database backups known for a provided site |
+| BackupFiles | [BackupFilesRequest](#ddev.sites.v1alpha1.BackupFilesRequest) | [BackupFilesResponse](#ddev.sites.v1alpha1.BackupFilesResponse) | BackupFiles backups up a currently running site environment to the staging area |
+| RestoreFiles | [RestoreFilesRequest](#ddev.sites.v1alpha1.RestoreFilesRequest) | [RestoreFilesResponse](#ddev.sites.v1alpha1.RestoreFilesResponse) | RestoreFiles restores the current staging area to a sites environment |
+| PushFileBackup | [PushFileBackupRequest](#ddev.sites.v1alpha1.PushFileBackupRequest) | [PushFileBackupResponse](#ddev.sites.v1alpha1.PushFileBackupResponse) | PushFile upload file assets to a sites backup staging area |
+| PushFileBackupStream | [PushFileBackupRequest](#ddev.sites.v1alpha1.PushFileBackupRequest) stream | [PushFileBackupResponse](#ddev.sites.v1alpha1.PushFileBackupResponse) | PushFileStream allows client side streaming of large files to a staged backup area |
+| PullFileBackupStream | [PullFileBackupRequest](#ddev.sites.v1alpha1.PullFileBackupRequest) | [PullFileBackupResponse](#ddev.sites.v1alpha1.PullFileBackupResponse) stream | PullFileStream streams currently staged file[s] from the server and pulls them down to a local source |
+| DescribeFileBackup | [DescribeFileBackupRequest](#ddev.sites.v1alpha1.DescribeFileBackupRequest) | [DescribeFileBackupResponse](#ddev.sites.v1alpha1.DescribeFileBackupResponse) | DescribeFiles returns the metadata for current files staged for a restore operation |
+| ListFileBackups | [ListFileBackupsRequest](#ddev.sites.v1alpha1.ListFileBackupsRequest) | [ListFileBackupsResponse](#ddev.sites.v1alpha1.ListFileBackupsResponse) | Lists file backups known for a provided site |
 
 
 

--- a/live/sites/v1alpha1/site.proto
+++ b/live/sites/v1alpha1/site.proto
@@ -464,11 +464,6 @@ message ListSiteResponse {
 }
 
 message UpdateSiteRequest {
-    /*
-  `Required`
-  The name of the site (needed to reference the existing site)
-  */
-  string name = 1;
 
   /*
   `Required`

--- a/live/sites/v1alpha1/site.proto
+++ b/live/sites/v1alpha1/site.proto
@@ -129,6 +129,12 @@ message Site {
   SiteStatus status = 15;
 
   /*
+    `Optional`
+    Mutable attributes for a site.
+  */
+  Attributes attributes = 16;
+  
+  /*
   `Optional`
   The version of the CMS used for the site
   */

--- a/live/sites/v1alpha1/site.proto
+++ b/live/sites/v1alpha1/site.proto
@@ -464,77 +464,11 @@ message ListSiteResponse {
 }
 
 message UpdateSiteRequest {
-    /*
+  /*
   `Required`
-  The name of the site (needed to reference the existing site)
+  The requested site.
   */
-  string name = 1;
-
-  /*
-  `Optional`
-  */
-  oneof Repository {
-    GitRepository git = 16;
-  }
-
-  /*
-  `Optional`
-  Specify tags for a site
-  */
-  map<string, string> tags = 17;
-
-  /*
-  `Optional`
-  The version of the CMS used for the site
-  */
-  string version = 18;
-
-  /*
-  `Optional`
-  Whether to run composer install when creating the site image
-  */
-  bool composerInstall = 19;
-
-  /*
-  `Optional`
-  If `composerInstall` is set, use this flags to specify which args are passed to composer install
-  */
-  repeated string composerArgs = 20;
-
-  /*
-  `Optional`
-  */
-  Cron cron = 21;
-
-  /*
-  `Optional`
-  The relative docroot of the site, like 'docroot' or 'htdocs' or 'web'. Defaults to empty, the repository's root directory.
-  */
-  string DocRoot = 22;
-  
-  /*
-  `Optional`
-  A list of persistent mount paths relative to docroot (ex. content/uploads). 
-  */
-  repeated string persistentPaths = 23;
-
-  /*
-  `Optional`
-  A list of ephemeral mount paths relative to docroot
-  */
-  repeated string ephemeralPaths = 24;
-
-  /*
-  `Optional`
-  Specify the amount of time after which the site should be considered expired and garbage collected. Supported units are minutes, hours, days, with max of 5 days (e.g. 90m, 3h, 5d, etc.), empty string means no expiration.
-  */
-  string expiry = 25;
-  
-  /*
-  `Optional`
-  Specify the version of PHP for the site
-  */
-  string phpVersion = 26;
+  Site site = 1;
 }
 
 message UpdateSiteResponse {

--- a/live/sites/v1alpha1/site.proto
+++ b/live/sites/v1alpha1/site.proto
@@ -458,6 +458,12 @@ message ListSiteResponse {
 }
 
 message UpdateSiteRequest {
+    /*
+  `Required`
+  The name of the site (needed to reference the existing site)
+  */
+  string name = 1;
+
   /*
   `Optional`
   */

--- a/live/sites/v1alpha1/site.proto
+++ b/live/sites/v1alpha1/site.proto
@@ -464,6 +464,12 @@ message ListSiteResponse {
 }
 
 message UpdateSiteRequest {
+    /*
+  `Required`
+  The name of the site (needed to reference the existing site)
+  */
+  string name = 1;
+
   /*
   `Required`
   The requested site.

--- a/live/sites/v1alpha1/site.proto
+++ b/live/sites/v1alpha1/site.proto
@@ -103,45 +103,79 @@ message Site {
   */
   repeated string urls = 5;
 
+  // NOTE: when beta, clean up attribute number 
+  message Attributes {
+    /*
+    `Optional`
+    Specify tags for a site
+    */
+    map<string, string> tags = 16;
+
+    /*
+    `Optional`
+    */
+    Cron cron = 21;
+
+    /*
+    `Optional`
+    Specify the amount of time after which the site should be considered expired and garbage collected. Supported units are minutes, hours, days, with max of 5 days (e.g. 90m, 3h, 5d, etc.), empty string means no expiration.
+    */
+    string expiry = 25;
+  }
   /*
+  `Optional`
   A set of different status descriptions for a site
   */
   SiteStatus status = 15;
 
   /*
+  `Optional`
   The version of the CMS used for the site
   */
   string version = 18;
 
   /*
+  `Optional`
   Whether to run composer install when creating the site image
   */
   bool composerInstall = 19;
 
   /*
+  `Optional`
   If `composerInstall` is set, use this flags to specify which args are passed to composer install
   */
   repeated string composerArgs = 20;
 
   /*
   `Optional`
+  `Deprecated`
+  Please use Attributes.Cron
   */
   Cron cron = 21;
 
   /*
+  `Optional`
   The relative docroot of the site, like 'docroot' or 'htdocs' or 'web'. Defaults to empty, the repository's root directory.
   */
   string DocRoot = 22;
   
   /*
+  `Optional`
   A list of persistent mount paths relative to docroot (ex. content/uploads). 
   */
   repeated string persistentPaths = 23;
 
   /*
+  `Optional`
   A list of ephemeral mount paths relative to docroot
   */
   repeated string ephemeralPaths = 24;
+
+  /*
+  `Optional`
+  Specify the version of PHP for the site
+  */
+  string phpVersion = 26;
 }
 
 message CloneOperation {
@@ -316,6 +350,12 @@ message CreateSiteRequest {
 
   /*
   `Optional`
+  Specify tags for a site
+  */
+  map<string, string> tags = 16;
+
+  /*
+  `Optional`
   The version of the CMS used for the site
   */
   string version = 18;
@@ -354,6 +394,18 @@ message CreateSiteRequest {
   A list of ephemeral mount paths relative to docroot
   */
   repeated string ephemeralPaths = 24;
+
+  /*
+  `Optional`
+  Specify the amount of time after which the site should be considered expired and garbage collected. Supported units are minutes, hours, days, with max of 5 days (e.g. 90m, 3h, 5d, etc.), empty string means no expiration.
+  */
+  string expiry = 25;
+  
+  /*
+  `Optional`
+  Specify the version of PHP for the site
+  */
+  string phpVersion = 26;
 }
 
 /*
@@ -405,22 +457,80 @@ message ListSiteResponse {
   repeated Site sites = 1;
 }
 
-/*
-  TODO
-*/
 message UpdateSiteRequest {
+  /*
+  `Optional`
+  */
+  oneof Repository {
+    GitRepository git = 16;
+  }
 
   /*
+  `Optional`
+  Specify tags for a site
   */
+  map<string, string> tags = 17;
+
+  /*
+  `Optional`
+  The version of the CMS used for the site
+  */
+  string version = 18;
+
+  /*
+  `Optional`
+  Whether to run composer install when creating the site image
+  */
+  bool composerInstall = 19;
+
+  /*
+  `Optional`
+  If `composerInstall` is set, use this flags to specify which args are passed to composer install
+  */
+  repeated string composerArgs = 20;
+
+  /*
+  `Optional`
+  */
+  Cron cron = 21;
+
+  /*
+  `Optional`
+  The relative docroot of the site, like 'docroot' or 'htdocs' or 'web'. Defaults to empty, the repository's root directory.
+  */
+  string DocRoot = 22;
+  
+  /*
+  `Optional`
+  A list of persistent mount paths relative to docroot (ex. content/uploads). 
+  */
+  repeated string persistentPaths = 23;
+
+  /*
+  `Optional`
+  A list of ephemeral mount paths relative to docroot
+  */
+  repeated string ephemeralPaths = 24;
+
+  /*
+  `Optional`
+  Specify the amount of time after which the site should be considered expired and garbage collected. Supported units are minutes, hours, days, with max of 5 days (e.g. 90m, 3h, 5d, etc.), empty string means no expiration.
+  */
+  string expiry = 25;
+  
+  /*
+  `Optional`
+  Specify the version of PHP for the site
+  */
+  string phpVersion = 26;
 }
 
-/*
-TODO
-*/
 message UpdateSiteResponse {
-
   /*
+  `OutputOnly`
+  The requested site.
   */
+  Site site = 1;
 }
 
 /*


### PR DESCRIPTION
- add unsupported fields to `Site` object
  - `phpVersion`
  - `expiry`
  - `tags`
- add unsupported fields to `CreateSiteRequest`
...
- add fields to `UpdateSiteRequest`
  - many of the fields in the `CreateSiteRequest` that can be used
- add fields to `UpdateSiteResponse`
  - `Site` object
   NOTE: this UpdateSiteRequest works under the CURRENT assumption that @drekle & I came to:
    > client side we need to first GET the existing site
    > merge the requested updates from client to existing site
    > pass the newly merged site object into this UpdateSiteRequest

NOTE: changes to `doc/api/administration-api.md` and `doc/api/site-api.md` are generated using `make doc`.