### PR TITLE
Revert "Add site creation timestamp"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ prepare-release:
 	mkdir -p build/dep
 	# TODO: Bazel
 	if [ ! -d build/dep/googleapis ];then git clone https://github.com/googleapis/googleapis.git build/dep/googleapis; fi
-	if [ ! -d build/dep/protobuf ];then git clone https://github.com/protocolbuffers/protobuf.git build/dep/protobuf; fi
 
 push-builder:
 	docker build -f Docker-protoc -t drud/protoc-builder .
@@ -52,8 +51,6 @@ build-js: prepare-release
 	drud/protoc-builder \
 	protoc \
 	--proto_path=/proto \
-	-I=/proto/build/dep/googleapis \
-	-I=/proto/build/dep/protobuf/src \
 	--js_out=import_style=commonjs,binary:/proto/build/js \
 	${SITE_PROTOS} ${ADMIN_PROTOS}
 
@@ -65,12 +62,10 @@ release-js: build-js
 build-ts: prepare-release
 	docker run --rm \
 	--user ${USER_ID} \
-	-v ${ROOT_DIR}:/proto \
+	-v ${ROOT_DIR}/:/proto \
 	drud/protoc-builder \
 	protoc \
 	--proto_path=/proto \
-	-I=/proto/build/dep/googleapis \
-	-I=/proto/build/dep/protobuf/src \
 	--js_out=import_style=commonjs:/proto/build/ts \
 	--grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext:/proto/build/ts \
 	${SITE_PROTOS} ${ADMIN_PROTOS}

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,15 +32,3 @@ http_archive(
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 gazelle_dependencies()
-
-# Below Import used for importing Google Timestamp proto
-http_archive(
-    name = "com_google_protobuf",
-    sha256 = "d0f5f605d0d656007ce6c8b5a82df3037e1d8fe8b121ed42e536f569dec16113",
-    strip_prefix = "protobuf-3.14.0",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.14.0.tar.gz"],
-)
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()

--- a/live/sites/v1alpha1/BUILD.bazel
+++ b/live/sites/v1alpha1/BUILD.bazel
@@ -12,9 +12,6 @@ proto_library(
         "site.proto",
     ],
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_google_protobuf//:timestamp_proto",
-    ],
 )
 
 go_proto_library(

--- a/live/sites/v1alpha1/site.proto
+++ b/live/sites/v1alpha1/site.proto
@@ -17,7 +17,6 @@ syntax = "proto3";
 package ddev.sites.v1alpha1;
 
 import "live/sites/v1alpha1/metadata.proto";
-import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/drud/site-api/gen/live/sites/v1alpha1";
 option java_multiple_files = true;
@@ -103,11 +102,6 @@ message Site {
   The URLs for the site
   */
   repeated string urls = 5;
-
-  /*
-  Creation Timestamp of site using RFC-3339
-  */
-  google.protobuf.Timestamp creationTime = 6;
 
   // NOTE: when beta, clean up attribute number 
   message Attributes {


### PR DESCRIPTION
Reverts drud/ddev-apis#37

we will be using `string` for `creationTime` because of unforeseen difficulties in using the google timestamp struct because remote proto repos that are referenced aren't generated in this repo.