### PR TITLE
Add timestamp string

### DIFF
--- a/doc/api/site-api.md
+++ b/doc/api/site-api.md
@@ -816,6 +816,7 @@ Cron manages if and when the CMS cron executes
 | git | [GitRepository](#ddev.sites.v1alpha1.GitRepository) |  |  |
 | type | [SiteType](#ddev.sites.v1alpha1.SiteType) |  | The type of the CMS used for the site |
 | urls | [string](#string) | repeated | The URLs for the site |
+| creationTime | [string](#string) |  |  |
 | status | [SiteStatus](#ddev.sites.v1alpha1.SiteStatus) |  | `Optional` A set of different status descriptions for a site |
 | attributes | [Site.Attributes](#ddev.sites.v1alpha1.Site.Attributes) |  | `Optional` Mutable attributes for a site. |
 | version | [string](#string) |  | `Optional` The version of the CMS used for the site |

--- a/live/sites/v1alpha1/site.proto
+++ b/live/sites/v1alpha1/site.proto
@@ -103,6 +103,8 @@ message Site {
   */
   repeated string urls = 5;
 
+  string creationTime = 6;
+  
   // NOTE: when beta, clean up attribute number 
   message Attributes {
     /*


### PR DESCRIPTION
## Which issue(s) this PR fixes:
Fixes # https://ddevhq.atlassian.net/browse/DEV-94

in response to @wozniakjan 's comment about `expiry` message https://github.com/drud/ddev-live-client/pull/536#discussion_r570839934 in the CLI

This PR adds in a `creationTime` field for `Site` message, which is necessary to re-implement the expiry dialog check in the CLI (and can be used by the UI to display to users the creation-time of their site)