### PR TITLE
Workspace will now contain a reference to the subscription

### DIFF
--- a/doc/api/administration-api.md
+++ b/doc/api/administration-api.md
@@ -3,9 +3,6 @@
 
 ## Table of Contents
 
-- [live/administration/v1alpha1/service.proto](#live/administration/v1alpha1/service.proto)
-    - [Administration](#ddev.administration.v1alpha1.Administration)
-  
 - [live/administration/v1alpha1/auth.proto](#live/administration/v1alpha1/auth.proto)
     - [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest)
     - [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse)
@@ -28,22 +25,8 @@
   
     - [Capability](#ddev.administration.v1alpha1.Capability)
   
-- [live/administration/v1alpha1/githubintegration.proto](#live/administration/v1alpha1/githubintegration.proto)
-    - [CreateGithubIntegrationRequest](#ddev.administration.v1alpha1.CreateGithubIntegrationRequest)
-    - [CreateGithubIntegrationResponse](#ddev.administration.v1alpha1.CreateGithubIntegrationResponse)
-    - [DeleteGithubIntegrationRequest](#ddev.administration.v1alpha1.DeleteGithubIntegrationRequest)
-    - [DeleteGithubIntegrationResponse](#ddev.administration.v1alpha1.DeleteGithubIntegrationResponse)
-    - [GetRepositoryMetadataRequest](#ddev.administration.v1alpha1.GetRepositoryMetadataRequest)
-    - [GetRepositoryMetadataResponse](#ddev.administration.v1alpha1.GetRepositoryMetadataResponse)
-    - [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest)
-    - [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse)
-    - [GithubRepositoryName](#ddev.administration.v1alpha1.GithubRepositoryName)
-    - [GithubRepositoryOwner](#ddev.administration.v1alpha1.GithubRepositoryOwner)
-    - [GithubRepositoryReference](#ddev.administration.v1alpha1.GithubRepositoryReference)
-    - [ListGithubRepositoriesRequest](#ddev.administration.v1alpha1.ListGithubRepositoriesRequest)
-    - [ListGithubRepositoriesResponse](#ddev.administration.v1alpha1.ListGithubRepositoriesResponse)
-    - [UpdateGithubIntegrationRequest](#ddev.administration.v1alpha1.UpdateGithubIntegrationRequest)
-    - [UpdateGithubIntegrationResponse](#ddev.administration.v1alpha1.UpdateGithubIntegrationResponse)
+- [live/administration/v1alpha1/service.proto](#live/administration/v1alpha1/service.proto)
+    - [Administration](#ddev.administration.v1alpha1.Administration)
   
 - [live/administration/v1alpha1/workspace.proto](#live/administration/v1alpha1/workspace.proto)
     - [AddWorkspaceAdminRequest](#ddev.administration.v1alpha1.AddWorkspaceAdminRequest)
@@ -81,74 +64,24 @@
   
     - [ReferenceType](#ddev.administration.v1alpha1.ReferenceType)
   
+- [live/administration/v1alpha1/githubintegration.proto](#live/administration/v1alpha1/githubintegration.proto)
+    - [CreateGithubIntegrationRequest](#ddev.administration.v1alpha1.CreateGithubIntegrationRequest)
+    - [CreateGithubIntegrationResponse](#ddev.administration.v1alpha1.CreateGithubIntegrationResponse)
+    - [DeleteGithubIntegrationRequest](#ddev.administration.v1alpha1.DeleteGithubIntegrationRequest)
+    - [DeleteGithubIntegrationResponse](#ddev.administration.v1alpha1.DeleteGithubIntegrationResponse)
+    - [GetRepositoryMetadataRequest](#ddev.administration.v1alpha1.GetRepositoryMetadataRequest)
+    - [GetRepositoryMetadataResponse](#ddev.administration.v1alpha1.GetRepositoryMetadataResponse)
+    - [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest)
+    - [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse)
+    - [GithubRepositoryName](#ddev.administration.v1alpha1.GithubRepositoryName)
+    - [GithubRepositoryOwner](#ddev.administration.v1alpha1.GithubRepositoryOwner)
+    - [GithubRepositoryReference](#ddev.administration.v1alpha1.GithubRepositoryReference)
+    - [ListGithubRepositoriesRequest](#ddev.administration.v1alpha1.ListGithubRepositoriesRequest)
+    - [ListGithubRepositoriesResponse](#ddev.administration.v1alpha1.ListGithubRepositoriesResponse)
+    - [UpdateGithubIntegrationRequest](#ddev.administration.v1alpha1.UpdateGithubIntegrationRequest)
+    - [UpdateGithubIntegrationResponse](#ddev.administration.v1alpha1.UpdateGithubIntegrationResponse)
+  
 - [Scalar Value Types](#scalar-value-types)
-
-
-
-<a name="live/administration/v1alpha1/service.proto"></a>
-<p align="right"><a href="#top">Top</a></p>
-
-## live/administration/v1alpha1/service.proto
-
-
- 
-
- 
-
- 
-
-
-<a name="ddev.administration.v1alpha1.Administration"></a>
-
-### Administration
-The Billing service provides administrative functions over a users ddev-live account.
-To access the billing service consumers will have to initialize an authenticated client.  This requires
-several metadata to be passed to the client.
-
-`x-auth-token` which is a authentication token for the call.  In most cases this will be a temporary token 
-issued by the API.  This can be the integration token provided on the dashboard when retrieving temporary tokens.
-
-`x-ddev-workspace` which is the workspace for all workspace scoped procedures.  For example a client request `ListSubscriptions` will list all subscriptions in the workspace whose value is derived from the key `x-ddev-workspace`.
-
-| Method Name | Request Type | Response Type | Description |
-| ----------- | ------------ | ------------- | ------------|
-| CreateToken | [CreateTokenRequest](#ddev.administration.v1alpha1.CreateTokenRequest) | [CreateTokenResponse](#ddev.administration.v1alpha1.CreateTokenResponse) | Creates an ID token from a refresh token |
-| CreateRoles | [CreateRoleRequest](#ddev.administration.v1alpha1.CreateRoleRequest) | [CreateRoleResponse](#ddev.administration.v1alpha1.CreateRoleResponse) | Creates a Role |
-| DescribeRole | [DescribeRoleRequest](#ddev.administration.v1alpha1.DescribeRoleRequest) | [DescribeRoleResponse](#ddev.administration.v1alpha1.DescribeRoleResponse) | Describes a named role |
-| ListRoles | [ListRolesRequest](#ddev.administration.v1alpha1.ListRolesRequest) | [ListRolesResponse](#ddev.administration.v1alpha1.ListRolesResponse) | Lists all known roles |
-| SetCapabilities | [SetCapabilitiesRequest](#ddev.administration.v1alpha1.SetCapabilitiesRequest) | [SetCapabilitiesResponse](#ddev.administration.v1alpha1.SetCapabilitiesResponse) | Updates a users API capabilities. Will requre a refresh of their token through CreateToken. |
-| ListCapabilities | [ListCapabilitiesRequest](#ddev.administration.v1alpha1.ListCapabilitiesRequest) | [ListCapabilitiesResponse](#ddev.administration.v1alpha1.ListCapabilitiesResponse) | Lists a users API capabilities. |
-| ListWorkspaces | [ListWorkspaceRequest](#ddev.administration.v1alpha1.ListWorkspaceRequest) | [ListWorkspaceResponse](#ddev.administration.v1alpha1.ListWorkspaceResponse) | ListWorkspaces will return a list of workspaces the user has authorization for |
-| AddWorkspaceAdmin | [AddWorkspaceAdminRequest](#ddev.administration.v1alpha1.AddWorkspaceAdminRequest) | [AddWorkspaceAdminResponse](#ddev.administration.v1alpha1.AddWorkspaceAdminResponse) | Add an administrator to a workspace. Requires a workspace administrator token. |
-| AddWorkspaceDeveloper | [AddWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest) | [AddWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse) | Add a developer to a workspace. Requires a workspace administrator token. |
-| DeleteWorkspaceAdmin | [DeleteWorkspaceAdminRequest](#ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest) | [DeleteWorkspaceAdminResponse](#ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse) | Remove an administrator from a workspace. Requires a workspace administrator token. An administrator cannot remove themselves. |
-| DeleteWorkspaceDeveloper | [DeleteWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest) | [DeleteWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse) | Remove a developer from a workspace. Requires a workspace administrator token. |
-| IsAuthTokenViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can read the API scopes a user has. |
-| IsAuthTokenEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can issue different API access scopes within an organization |
-| IsBillingViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can access billing artifacts such as invoices |
-| IsBillingEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can modify elements such as their subscription |
-| IsWorkspaceAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is an admin of a workspace |
-| IsWorkspaceViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which has read capability for workspace objects |
-| IsSiteEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is capable of creating or modifying a site |
-| IsSiteViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is capable of viewing site specifications created in a workspace |
-| IsLogsViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows for the viewing of site logs |
-| IsSiteExecutor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows for the execution of commands inside a running site container |
-| IsDatabaseAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows full control over site databases, which includes restore and push operations |
-| IsDatabaseViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows pull access for a sites database |
-| IsFileAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows full control over site files, which includes restore and push operations |
-| IsFileViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows pull access for a sites files |
-| CreateGithubIntegration | [CreateGithubIntegrationRequest](#ddev.administration.v1alpha1.CreateGithubIntegrationRequest) | [CreateGithubIntegrationResponse](#ddev.administration.v1alpha1.CreateGithubIntegrationResponse) | Creates a github integration from an installation ID |
-| DeleteGithubIntegration | [DeleteGithubIntegrationRequest](#ddev.administration.v1alpha1.DeleteGithubIntegrationRequest) | [DeleteGithubIntegrationResponse](#ddev.administration.v1alpha1.DeleteGithubIntegrationResponse) | Deletes a github integration |
-| UpdateGithubIntegration | [UpdateGithubIntegrationRequest](#ddev.administration.v1alpha1.UpdateGithubIntegrationRequest) | [UpdateGithubIntegrationResponse](#ddev.administration.v1alpha1.UpdateGithubIntegrationResponse) | Updates a github integration |
-| ListGithubRepositories | [ListGithubRepositoriesRequest](#ddev.administration.v1alpha1.ListGithubRepositoriesRequest) | [ListGithubRepositoriesResponse](#ddev.administration.v1alpha1.ListGithubRepositoriesResponse) | List github repositories |
-| CreateGitlabIntegration | [CreateGitlabIntegrationRequest](#ddev.administration.v1alpha1.CreateGitlabIntegrationRequest) | [CreateGitlabIntegrationResponse](#ddev.administration.v1alpha1.CreateGitlabIntegrationResponse) | Creates a gitlab integration from an installation ID |
-| DeleteGitlabIntegration | [DeleteGitlabIntegrationRequest](#ddev.administration.v1alpha1.DeleteGitlabIntegrationRequest) | [DeleteGitlabIntegrationResponse](#ddev.administration.v1alpha1.DeleteGitlabIntegrationResponse) | Deletes a gitlab integration |
-| ListGitlabIntegrations | [ListGitlabIntegrationsRequest](#ddev.administration.v1alpha1.ListGitlabIntegrationsRequest) | [ListGitlabIntegrationsResponse](#ddev.administration.v1alpha1.ListGitlabIntegrationsResponse) | Lists gitlab integrations |
-| ListGitlabProjects | [ListGitlabProjectsRequest](#ddev.administration.v1alpha1.ListGitlabProjectsRequest) | [ListGitlabProjectsResponse](#ddev.administration.v1alpha1.ListGitlabProjectsResponse) | List gitlab projects |
-| GetGitlabProjectMetadata | [GetGitlabProjectMetadataRequest](#ddev.administration.v1alpha1.GetGitlabProjectMetadataRequest) | [GetGitlabProjectMetadataResponse](#ddev.administration.v1alpha1.GetGitlabProjectMetadataResponse) | Returns metadata of a Gitlab project by ID |
-| GetRepositoryMetadata | [GetRepositoryMetadataRequest](#ddev.administration.v1alpha1.GetRepositoryMetadataRequest) | [GetRepositoryMetadataResponse](#ddev.administration.v1alpha1.GetRepositoryMetadataResponse) | Returns metadata of a repository by ID |
-
- 
 
 
 
@@ -464,244 +397,10 @@ Describes a set of access policies for a user
 
 
 
-<a name="live/administration/v1alpha1/githubintegration.proto"></a>
+<a name="live/administration/v1alpha1/service.proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## live/administration/v1alpha1/githubintegration.proto
-
-
-
-<a name="ddev.administration.v1alpha1.CreateGithubIntegrationRequest"></a>
-
-### CreateGithubIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The new GithubIntegration resource |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.CreateGithubIntegrationResponse"></a>
-
-### CreateGithubIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The new GithubIntegration resource |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteGithubIntegrationRequest"></a>
-
-### DeleteGithubIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The deleted GithubIntegration resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteGithubIntegrationResponse"></a>
-
-### DeleteGithubIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The deleted GithubIntegration resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GetRepositoryMetadataRequest"></a>
-
-### GetRepositoryMetadataRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `Required` The Repository ID. |
-| owner | [string](#string) |  | `Optional` The Repository owner. |
-| name | [string](#string) |  | `Optional` The Repository name. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GetRepositoryMetadataResponse"></a>
-
-### GetRepositoryMetadataResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `OutputOnly` The Repository ID. |
-| owner | [string](#string) |  | `OutputOnly` The Repository owner. |
-| name | [string](#string) |  | `OutputOnly` The Repository name. |
-| meta | [GithubRepositoryReference](#ddev.administration.v1alpha1.GithubRepositoryReference) | repeated | `OutputOnly` The Repository metadata. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubIntegrationRequest"></a>
-
-### GithubIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| installationID | [int64](#int64) |  | `Required` Installation ID. |
-| githubAppID | [int64](#int64) |  | `Required` Github App ID. |
-| githubAppSlug | [string](#string) |  | `Optional` Github App Slug. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubIntegrationResponse"></a>
-
-### GithubIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| installationID | [int64](#int64) |  | `Required` Installation ID. |
-| githubAppID | [int64](#int64) |  | `Required` Github App ID. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubRepositoryName"></a>
-
-### GithubRepositoryName
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `OutputOnly` The Repository ID. |
-| name | [string](#string) |  | `OutputOnly` The Repository name. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubRepositoryOwner"></a>
-
-### GithubRepositoryOwner
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | `OutputOnly` The Owner name. |
-| repositories | [GithubRepositoryName](#ddev.administration.v1alpha1.GithubRepositoryName) | repeated | `OutputOnly` List of Repository Names for this Owner. |
-| installationID | [string](#string) |  | `OutputOnly` The Installation ID of this Owner&#39;s GitHub App installation. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubRepositoryReference"></a>
-
-### GithubRepositoryReference
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| sha | [string](#string) |  | `OutputOnly` Reference commit sha. |
-| branch | [string](#string) |  |  |
-| tag | [string](#string) |  |  |
-| pullrequest | [string](#string) |  |  |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListGithubRepositoriesRequest"></a>
-
-### ListGithubRepositoriesRequest
-
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListGithubRepositoriesResponse"></a>
-
-### ListGithubRepositoriesResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| items | [GithubRepositoryOwner](#ddev.administration.v1alpha1.GithubRepositoryOwner) | repeated | `OutputOnly` Github repositories available to the user. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.UpdateGithubIntegrationRequest"></a>
-
-### UpdateGithubIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The updated GithubIntegration resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.UpdateGithubIntegrationResponse"></a>
-
-### UpdateGithubIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The updated GithubIntegration resource. |
-
-
-
+## live/administration/v1alpha1/service.proto
 
 
  
@@ -709,6 +408,57 @@ Describes a set of access policies for a user
  
 
  
+
+
+<a name="ddev.administration.v1alpha1.Administration"></a>
+
+### Administration
+The Billing service provides administrative functions over a users ddev-live account.
+To access the billing service consumers will have to initialize an authenticated client.  This requires
+several metadata to be passed to the client.
+
+`x-auth-token` which is a authentication token for the call.  In most cases this will be a temporary token 
+issued by the API.  This can be the integration token provided on the dashboard when retrieving temporary tokens.
+
+`x-ddev-workspace` which is the workspace for all workspace scoped procedures.  For example a client request `ListSubscriptions` will list all subscriptions in the workspace whose value is derived from the key `x-ddev-workspace`.
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| CreateToken | [CreateTokenRequest](#ddev.administration.v1alpha1.CreateTokenRequest) | [CreateTokenResponse](#ddev.administration.v1alpha1.CreateTokenResponse) | Creates an ID token from a refresh token |
+| CreateRoles | [CreateRoleRequest](#ddev.administration.v1alpha1.CreateRoleRequest) | [CreateRoleResponse](#ddev.administration.v1alpha1.CreateRoleResponse) | Creates a Role |
+| DescribeRole | [DescribeRoleRequest](#ddev.administration.v1alpha1.DescribeRoleRequest) | [DescribeRoleResponse](#ddev.administration.v1alpha1.DescribeRoleResponse) | Describes a named role |
+| ListRoles | [ListRolesRequest](#ddev.administration.v1alpha1.ListRolesRequest) | [ListRolesResponse](#ddev.administration.v1alpha1.ListRolesResponse) | Lists all known roles |
+| SetCapabilities | [SetCapabilitiesRequest](#ddev.administration.v1alpha1.SetCapabilitiesRequest) | [SetCapabilitiesResponse](#ddev.administration.v1alpha1.SetCapabilitiesResponse) | Updates a users API capabilities. Will requre a refresh of their token through CreateToken. |
+| ListCapabilities | [ListCapabilitiesRequest](#ddev.administration.v1alpha1.ListCapabilitiesRequest) | [ListCapabilitiesResponse](#ddev.administration.v1alpha1.ListCapabilitiesResponse) | Lists a users API capabilities. |
+| ListWorkspaces | [ListWorkspaceRequest](#ddev.administration.v1alpha1.ListWorkspaceRequest) | [ListWorkspaceResponse](#ddev.administration.v1alpha1.ListWorkspaceResponse) | ListWorkspaces will return a list of workspaces the user has authorization for |
+| AddWorkspaceAdmin | [AddWorkspaceAdminRequest](#ddev.administration.v1alpha1.AddWorkspaceAdminRequest) | [AddWorkspaceAdminResponse](#ddev.administration.v1alpha1.AddWorkspaceAdminResponse) | Add an administrator to a workspace. Requires a workspace administrator token. |
+| AddWorkspaceDeveloper | [AddWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest) | [AddWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse) | Add a developer to a workspace. Requires a workspace administrator token. |
+| DeleteWorkspaceAdmin | [DeleteWorkspaceAdminRequest](#ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest) | [DeleteWorkspaceAdminResponse](#ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse) | Remove an administrator from a workspace. Requires a workspace administrator token. An administrator cannot remove themselves. |
+| DeleteWorkspaceDeveloper | [DeleteWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest) | [DeleteWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse) | Remove a developer from a workspace. Requires a workspace administrator token. |
+| IsAuthTokenViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can read the API scopes a user has. |
+| IsAuthTokenEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can issue different API access scopes within an organization |
+| IsBillingViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can access billing artifacts such as invoices |
+| IsBillingEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can modify elements such as their subscription |
+| IsWorkspaceAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is an admin of a workspace |
+| IsWorkspaceViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which has read capability for workspace objects |
+| IsSiteEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is capable of creating or modifying a site |
+| IsSiteViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which is capable of viewing site specifications created in a workspace |
+| IsLogsViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows for the viewing of site logs |
+| IsSiteExecutor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows for the execution of commands inside a running site container |
+| IsDatabaseAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows full control over site databases, which includes restore and push operations |
+| IsDatabaseViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows pull access for a sites database |
+| IsFileAdmin | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows full control over site files, which includes restore and push operations |
+| IsFileViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which allows pull access for a sites files |
+| CreateGithubIntegration | [CreateGithubIntegrationRequest](#ddev.administration.v1alpha1.CreateGithubIntegrationRequest) | [CreateGithubIntegrationResponse](#ddev.administration.v1alpha1.CreateGithubIntegrationResponse) | Creates a github integration from an installation ID |
+| DeleteGithubIntegration | [DeleteGithubIntegrationRequest](#ddev.administration.v1alpha1.DeleteGithubIntegrationRequest) | [DeleteGithubIntegrationResponse](#ddev.administration.v1alpha1.DeleteGithubIntegrationResponse) | Deletes a github integration |
+| UpdateGithubIntegration | [UpdateGithubIntegrationRequest](#ddev.administration.v1alpha1.UpdateGithubIntegrationRequest) | [UpdateGithubIntegrationResponse](#ddev.administration.v1alpha1.UpdateGithubIntegrationResponse) | Updates a github integration |
+| ListGithubRepositories | [ListGithubRepositoriesRequest](#ddev.administration.v1alpha1.ListGithubRepositoriesRequest) | [ListGithubRepositoriesResponse](#ddev.administration.v1alpha1.ListGithubRepositoriesResponse) | List github repositories |
+| CreateGitlabIntegration | [CreateGitlabIntegrationRequest](#ddev.administration.v1alpha1.CreateGitlabIntegrationRequest) | [CreateGitlabIntegrationResponse](#ddev.administration.v1alpha1.CreateGitlabIntegrationResponse) | Creates a gitlab integration from an installation ID |
+| DeleteGitlabIntegration | [DeleteGitlabIntegrationRequest](#ddev.administration.v1alpha1.DeleteGitlabIntegrationRequest) | [DeleteGitlabIntegrationResponse](#ddev.administration.v1alpha1.DeleteGitlabIntegrationResponse) | Deletes a gitlab integration |
+| ListGitlabIntegrations | [ListGitlabIntegrationsRequest](#ddev.administration.v1alpha1.ListGitlabIntegrationsRequest) | [ListGitlabIntegrationsResponse](#ddev.administration.v1alpha1.ListGitlabIntegrationsResponse) | Lists gitlab integrations |
+| ListGitlabProjects | [ListGitlabProjectsRequest](#ddev.administration.v1alpha1.ListGitlabProjectsRequest) | [ListGitlabProjectsResponse](#ddev.administration.v1alpha1.ListGitlabProjectsResponse) | List gitlab projects |
+| GetGitlabProjectMetadata | [GetGitlabProjectMetadataRequest](#ddev.administration.v1alpha1.GetGitlabProjectMetadataRequest) | [GetGitlabProjectMetadataResponse](#ddev.administration.v1alpha1.GetGitlabProjectMetadataResponse) | Returns metadata of a Gitlab project by ID |
+| GetRepositoryMetadata | [GetRepositoryMetadataRequest](#ddev.administration.v1alpha1.GetRepositoryMetadataRequest) | [GetRepositoryMetadataResponse](#ddev.administration.v1alpha1.GetRepositoryMetadataResponse) | Returns metadata of a repository by ID |
 
  
 
@@ -886,6 +636,7 @@ Describes a set of access policies for a user
 | name | [string](#string) |  | `OutputOnly` Workspace Name. |
 | admins | [string](#string) | repeated | `OutputOnly` Administrators of the workspace |
 | developers | [string](#string) | repeated | `OutputOnly` Developers in the workspace |
+| subscription | [string](#string) |  | The ID of the subscription which this workspace belongs |
 
 
 
@@ -1196,6 +947,256 @@ If the request is set to DEVELOPER the response will contain any workspace where
 | Tag | 1 |  |
 | MR | 2 |  |
 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="live/administration/v1alpha1/githubintegration.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## live/administration/v1alpha1/githubintegration.proto
+
+
+
+<a name="ddev.administration.v1alpha1.CreateGithubIntegrationRequest"></a>
+
+### CreateGithubIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The new GithubIntegration resource |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.CreateGithubIntegrationResponse"></a>
+
+### CreateGithubIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The new GithubIntegration resource |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteGithubIntegrationRequest"></a>
+
+### DeleteGithubIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The deleted GithubIntegration resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteGithubIntegrationResponse"></a>
+
+### DeleteGithubIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The deleted GithubIntegration resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetRepositoryMetadataRequest"></a>
+
+### GetRepositoryMetadataRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `Required` The Repository ID. |
+| owner | [string](#string) |  | `Optional` The Repository owner. |
+| name | [string](#string) |  | `Optional` The Repository name. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetRepositoryMetadataResponse"></a>
+
+### GetRepositoryMetadataResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `OutputOnly` The Repository ID. |
+| owner | [string](#string) |  | `OutputOnly` The Repository owner. |
+| name | [string](#string) |  | `OutputOnly` The Repository name. |
+| meta | [GithubRepositoryReference](#ddev.administration.v1alpha1.GithubRepositoryReference) | repeated | `OutputOnly` The Repository metadata. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubIntegrationRequest"></a>
+
+### GithubIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| installationID | [int64](#int64) |  | `Required` Installation ID. |
+| githubAppID | [int64](#int64) |  | `Required` Github App ID. |
+| githubAppSlug | [string](#string) |  | `Optional` Github App Slug. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubIntegrationResponse"></a>
+
+### GithubIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| installationID | [int64](#int64) |  | `Required` Installation ID. |
+| githubAppID | [int64](#int64) |  | `Required` Github App ID. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubRepositoryName"></a>
+
+### GithubRepositoryName
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `OutputOnly` The Repository ID. |
+| name | [string](#string) |  | `OutputOnly` The Repository name. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubRepositoryOwner"></a>
+
+### GithubRepositoryOwner
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | `OutputOnly` The Owner name. |
+| repositories | [GithubRepositoryName](#ddev.administration.v1alpha1.GithubRepositoryName) | repeated | `OutputOnly` List of Repository Names for this Owner. |
+| installationID | [string](#string) |  | `OutputOnly` The Installation ID of this Owner&#39;s GitHub App installation. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubRepositoryReference"></a>
+
+### GithubRepositoryReference
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| sha | [string](#string) |  | `OutputOnly` Reference commit sha. |
+| branch | [string](#string) |  |  |
+| tag | [string](#string) |  |  |
+| pullrequest | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListGithubRepositoriesRequest"></a>
+
+### ListGithubRepositoriesRequest
+
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListGithubRepositoriesResponse"></a>
+
+### ListGithubRepositoriesResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| items | [GithubRepositoryOwner](#ddev.administration.v1alpha1.GithubRepositoryOwner) | repeated | `OutputOnly` Github repositories available to the user. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.UpdateGithubIntegrationRequest"></a>
+
+### UpdateGithubIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The updated GithubIntegration resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.UpdateGithubIntegrationResponse"></a>
+
+### UpdateGithubIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The updated GithubIntegration resource. |
+
+
+
+
+
+ 
 
  
 

--- a/live/administration/v1alpha1/workspace.proto
+++ b/live/administration/v1alpha1/workspace.proto
@@ -45,6 +45,11 @@ message Workspace {
     Developers in the workspace
     */
     repeated string developers = 3;
+
+    /*
+    The ID of the subscription which this workspace belongs
+    */
+    string subscription = 4;
 }
 
 


### PR DESCRIPTION
For query support it may be useful to determine the subscription associated to a workspace.

There is an issue where `make doc` reorders the documentation.  This can be fixed when the documentation generation is automated in github actions.