### PR TITLE
default workspace support

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -1,0 +1,21 @@
+name: Doc
+on: 
+  push:
+    branches:
+      - main
+jobs:
+  publish:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: release-doc
+        run: |
+          make doc
+      - name: Commit to common state repository
+        uses: drud/action-cross-commit@master
+        with:
+          source-folder: doc
+          destination-repository: https://${{ secrets.GIT_BUILD_TOKEN }}@github.com/drud/ddev-apis.git
+          destination-folder: doc
+          destination-branch: main
+          git-user: "Build User"
+          git-user-email: cicd@ddev.com

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,4 +66,15 @@ jobs:
           npmVersion=$(echo ${{steps.tagger.outputs.tag}} | sed s%^v%%)
           npm version $npmVersion
           npm publish --access public
-
+      - name: release-go
+        run: |
+          make release-go
+      - name: Commit to common state repository
+        uses: drud/action-cross-commit@master
+        with:
+          source-folder: bazel-bin/live
+          destination-repository: https://${{ secrets.GIT_BUILD_TOKEN }}@github.com/drud/ddev-apis.git
+          destination-folder: live
+          destination-branch: main
+          git-user: "Build User"
+          git-user-email: cicd@ddev.com

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,12 +69,21 @@ jobs:
       - name: release-go
         run: |
           make release-go
-      - name: Commit to common state repository
+      - name: Commit admin-api gen to ddev-apis-go
         uses: drud/action-cross-commit@master
         with:
-          source-folder: bazel-bin/live
-          destination-repository: https://${{ secrets.GIT_BUILD_TOKEN }}@github.com/drud/ddev-apis.git
-          destination-folder: live
+          source-folder: bazel-bin/admin_grpc/live/administration
+          destination-repository: https://${{ secrets.GIT_BUILD_TOKEN }}@github.com/drud/ddev-apis-go.git
+          destination-folder: live/administration
+          destination-branch: main
+          git-user: "Build User"
+          git-user-email: cicd@ddev.com
+      - name: Commit site-api gen to ddev-apis-go
+        uses: drud/action-cross-commit@master
+        with:
+          source-folder: bazel-bin/site_grpc/live/sites
+          destination-repository: https://${{ secrets.GIT_BUILD_TOKEN }}@github.com/drud/ddev-apis-go.git
+          destination-folder: live/sites
           destination-branch: main
           git-user: "Build User"
           git-user-email: cicd@ddev.com

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,7 +8,6 @@ gazelle(
     prefix = "github.com/drud/ddev-apis",
 )
 
-
 load("@rules_proto_grpc//go:defs.bzl", "go_grpc_compile")
 
 go_grpc_compile(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,3 +7,22 @@ gazelle(
     external = "vendored",
     prefix = "github.com/drud/ddev-apis",
 )
+
+
+load("@rules_proto_grpc//go:defs.bzl", "go_grpc_compile")
+
+go_grpc_compile(
+    name = "admin_grpc",
+    deps = [
+        "//live/administration/v1alpha1:v1alpha1_proto",
+    ],
+)
+
+load("@rules_proto_grpc//go:defs.bzl", "go_grpc_compile")
+
+go_grpc_compile(
+    name = "site_grpc",
+    deps = [
+        "//live/sites/v1alpha1:v1alpha1_proto",
+    ],
+)

--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,8 @@ push-builder:
 	docker push drud/protoc-builder
 
 build-go: prepare-release
-	protoc \
-	--proto_path=build/dep/googleapis \
-	--proto_path=. \
-	--go_out=plugins=grpc:build/go \
-	--swagger_out=allow_delete_body=true:build/go \
-	--grpc-gateway_out=allow_delete_body=true:build/go \
-	${SITE_PROTOS} ${ADMIN_PROTOS}
+	bazel build //:admin_grpc
+	bazel build //:site_grpc
 
 release-go: build-go
 	tar -zcvf build/release/go/go-gen-source.tar.gz build/go

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,3 +32,41 @@ http_archive(
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 gazelle_dependencies()
+
+go_repository(
+    name = "org_golang_google_grpc",
+    build_extra_args = ["-exclude=vendor"],
+    build_file_proto_mode = "disable_global",
+    importpath = "google.golang.org/grpc",
+    sum = "h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=",
+    version = "v1.29.1",
+)
+
+go_repository(
+    name = "org_golang_x_net",
+    importpath = "golang.org/x/net",
+    sum = "h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=",
+    version = "v0.0.0-20200324143707-d3edc9973b7e",
+)
+
+go_repository(
+    name = "org_golang_x_text",
+    importpath = "golang.org/x/text",
+    sum = "h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=",
+    version = "v0.3.2",
+)
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_proto_grpc",
+    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/1.0.2.tar.gz"],
+    sha256 = "5f0f2fc0199810c65a2de148a52ba0aff14d631d4e8202f41aff6a9d590a471b",
+    strip_prefix = "rules_proto_grpc-1.0.2",
+)
+
+load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_toolchains", "rules_proto_grpc_repos")
+
+rules_proto_grpc_toolchains()
+
+rules_proto_grpc_repos()

--- a/doc/api/administration-api.md
+++ b/doc/api/administration-api.md
@@ -637,7 +637,7 @@ issued by the API.  This can be the integration token provided on the dashboard 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | subscription | [string](#string) |  | `Required` The id of the subscription for the workspace |
-| workspace | [string](#string) |  | The name of the workspace in the subscription |
+| workspace | [string](#string) |  | `Required` The name of the workspace in the subscription |
 
 
 

--- a/doc/api/administration-api.md
+++ b/doc/api/administration-api.md
@@ -3,59 +3,6 @@
 
 ## Table of Contents
 
-- [live/administration/v1alpha1/workspace.proto](#live/administration/v1alpha1/workspace.proto)
-    - [AddWorkspaceAdminRequest](#ddev.administration.v1alpha1.AddWorkspaceAdminRequest)
-    - [AddWorkspaceAdminResponse](#ddev.administration.v1alpha1.AddWorkspaceAdminResponse)
-    - [AddWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest)
-    - [AddWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse)
-    - [DeleteWorkspaceAdminRequest](#ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest)
-    - [DeleteWorkspaceAdminResponse](#ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse)
-    - [DeleteWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest)
-    - [DeleteWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse)
-    - [ListWorkspaceRequest](#ddev.administration.v1alpha1.ListWorkspaceRequest)
-    - [ListWorkspaceResponse](#ddev.administration.v1alpha1.ListWorkspaceResponse)
-    - [Workspace](#ddev.administration.v1alpha1.Workspace)
-  
-    - [ListWorkspaceRequest.ListWorkspaceScope](#ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope)
-  
-- [live/administration/v1alpha1/githubintegration.proto](#live/administration/v1alpha1/githubintegration.proto)
-    - [CreateGithubIntegrationRequest](#ddev.administration.v1alpha1.CreateGithubIntegrationRequest)
-    - [CreateGithubIntegrationResponse](#ddev.administration.v1alpha1.CreateGithubIntegrationResponse)
-    - [DeleteGithubIntegrationRequest](#ddev.administration.v1alpha1.DeleteGithubIntegrationRequest)
-    - [DeleteGithubIntegrationResponse](#ddev.administration.v1alpha1.DeleteGithubIntegrationResponse)
-    - [GetRepositoryMetadataRequest](#ddev.administration.v1alpha1.GetRepositoryMetadataRequest)
-    - [GetRepositoryMetadataResponse](#ddev.administration.v1alpha1.GetRepositoryMetadataResponse)
-    - [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest)
-    - [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse)
-    - [GithubRepositoryName](#ddev.administration.v1alpha1.GithubRepositoryName)
-    - [GithubRepositoryOwner](#ddev.administration.v1alpha1.GithubRepositoryOwner)
-    - [GithubRepositoryReference](#ddev.administration.v1alpha1.GithubRepositoryReference)
-    - [ListGithubRepositoriesRequest](#ddev.administration.v1alpha1.ListGithubRepositoriesRequest)
-    - [ListGithubRepositoriesResponse](#ddev.administration.v1alpha1.ListGithubRepositoriesResponse)
-    - [UpdateGithubIntegrationRequest](#ddev.administration.v1alpha1.UpdateGithubIntegrationRequest)
-    - [UpdateGithubIntegrationResponse](#ddev.administration.v1alpha1.UpdateGithubIntegrationResponse)
-  
-- [live/administration/v1alpha1/gitlabintegration.proto](#live/administration/v1alpha1/gitlabintegration.proto)
-    - [CreateGitlabIntegrationRequest](#ddev.administration.v1alpha1.CreateGitlabIntegrationRequest)
-    - [CreateGitlabIntegrationResponse](#ddev.administration.v1alpha1.CreateGitlabIntegrationResponse)
-    - [DeleteGitlabIntegrationRequest](#ddev.administration.v1alpha1.DeleteGitlabIntegrationRequest)
-    - [DeleteGitlabIntegrationResponse](#ddev.administration.v1alpha1.DeleteGitlabIntegrationResponse)
-    - [GetGitlabIntegrationRequest](#ddev.administration.v1alpha1.GetGitlabIntegrationRequest)
-    - [GetGitlabIntegrationResponse](#ddev.administration.v1alpha1.GetGitlabIntegrationResponse)
-    - [GetGitlabProjectMetadataRequest](#ddev.administration.v1alpha1.GetGitlabProjectMetadataRequest)
-    - [GetGitlabProjectMetadataResponse](#ddev.administration.v1alpha1.GetGitlabProjectMetadataResponse)
-    - [GitlabIntegration](#ddev.administration.v1alpha1.GitlabIntegration)
-    - [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse)
-    - [GitlabProjectName](#ddev.administration.v1alpha1.GitlabProjectName)
-    - [GitlabProjectOwner](#ddev.administration.v1alpha1.GitlabProjectOwner)
-    - [GitlabProjectReference](#ddev.administration.v1alpha1.GitlabProjectReference)
-    - [ListGitlabIntegrationsRequest](#ddev.administration.v1alpha1.ListGitlabIntegrationsRequest)
-    - [ListGitlabIntegrationsResponse](#ddev.administration.v1alpha1.ListGitlabIntegrationsResponse)
-    - [ListGitlabProjectsRequest](#ddev.administration.v1alpha1.ListGitlabProjectsRequest)
-    - [ListGitlabProjectsResponse](#ddev.administration.v1alpha1.ListGitlabProjectsResponse)
-  
-    - [ReferenceType](#ddev.administration.v1alpha1.ReferenceType)
-  
 - [live/administration/v1alpha1/auth.proto](#live/administration/v1alpha1/auth.proto)
     - [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest)
     - [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse)
@@ -81,749 +28,62 @@
 - [live/administration/v1alpha1/service.proto](#live/administration/v1alpha1/service.proto)
     - [Administration](#ddev.administration.v1alpha1.Administration)
   
+- [live/administration/v1alpha1/workspace.proto](#live/administration/v1alpha1/workspace.proto)
+    - [AddWorkspaceAdminRequest](#ddev.administration.v1alpha1.AddWorkspaceAdminRequest)
+    - [AddWorkspaceAdminResponse](#ddev.administration.v1alpha1.AddWorkspaceAdminResponse)
+    - [AddWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest)
+    - [AddWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse)
+    - [DeleteWorkspaceAdminRequest](#ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest)
+    - [DeleteWorkspaceAdminResponse](#ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse)
+    - [DeleteWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest)
+    - [DeleteWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse)
+    - [ListWorkspaceRequest](#ddev.administration.v1alpha1.ListWorkspaceRequest)
+    - [ListWorkspaceResponse](#ddev.administration.v1alpha1.ListWorkspaceResponse)
+    - [SetDefaultWorkspaceRequest](#ddev.administration.v1alpha1.SetDefaultWorkspaceRequest)
+    - [SetDefaultWorkspaceResponse](#ddev.administration.v1alpha1.SetDefaultWorkspaceResponse)
+    - [Workspace](#ddev.administration.v1alpha1.Workspace)
+  
+    - [ListWorkspaceRequest.ListWorkspaceScope](#ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope)
+  
+- [live/administration/v1alpha1/gitlabintegration.proto](#live/administration/v1alpha1/gitlabintegration.proto)
+    - [CreateGitlabIntegrationRequest](#ddev.administration.v1alpha1.CreateGitlabIntegrationRequest)
+    - [CreateGitlabIntegrationResponse](#ddev.administration.v1alpha1.CreateGitlabIntegrationResponse)
+    - [DeleteGitlabIntegrationRequest](#ddev.administration.v1alpha1.DeleteGitlabIntegrationRequest)
+    - [DeleteGitlabIntegrationResponse](#ddev.administration.v1alpha1.DeleteGitlabIntegrationResponse)
+    - [GetGitlabIntegrationRequest](#ddev.administration.v1alpha1.GetGitlabIntegrationRequest)
+    - [GetGitlabIntegrationResponse](#ddev.administration.v1alpha1.GetGitlabIntegrationResponse)
+    - [GetGitlabProjectMetadataRequest](#ddev.administration.v1alpha1.GetGitlabProjectMetadataRequest)
+    - [GetGitlabProjectMetadataResponse](#ddev.administration.v1alpha1.GetGitlabProjectMetadataResponse)
+    - [GitlabIntegration](#ddev.administration.v1alpha1.GitlabIntegration)
+    - [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse)
+    - [GitlabProjectName](#ddev.administration.v1alpha1.GitlabProjectName)
+    - [GitlabProjectOwner](#ddev.administration.v1alpha1.GitlabProjectOwner)
+    - [GitlabProjectReference](#ddev.administration.v1alpha1.GitlabProjectReference)
+    - [ListGitlabIntegrationsRequest](#ddev.administration.v1alpha1.ListGitlabIntegrationsRequest)
+    - [ListGitlabIntegrationsResponse](#ddev.administration.v1alpha1.ListGitlabIntegrationsResponse)
+    - [ListGitlabProjectsRequest](#ddev.administration.v1alpha1.ListGitlabProjectsRequest)
+    - [ListGitlabProjectsResponse](#ddev.administration.v1alpha1.ListGitlabProjectsResponse)
+  
+    - [ReferenceType](#ddev.administration.v1alpha1.ReferenceType)
+  
+- [live/administration/v1alpha1/githubintegration.proto](#live/administration/v1alpha1/githubintegration.proto)
+    - [CreateGithubIntegrationRequest](#ddev.administration.v1alpha1.CreateGithubIntegrationRequest)
+    - [CreateGithubIntegrationResponse](#ddev.administration.v1alpha1.CreateGithubIntegrationResponse)
+    - [DeleteGithubIntegrationRequest](#ddev.administration.v1alpha1.DeleteGithubIntegrationRequest)
+    - [DeleteGithubIntegrationResponse](#ddev.administration.v1alpha1.DeleteGithubIntegrationResponse)
+    - [GetRepositoryMetadataRequest](#ddev.administration.v1alpha1.GetRepositoryMetadataRequest)
+    - [GetRepositoryMetadataResponse](#ddev.administration.v1alpha1.GetRepositoryMetadataResponse)
+    - [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest)
+    - [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse)
+    - [GithubRepositoryName](#ddev.administration.v1alpha1.GithubRepositoryName)
+    - [GithubRepositoryOwner](#ddev.administration.v1alpha1.GithubRepositoryOwner)
+    - [GithubRepositoryReference](#ddev.administration.v1alpha1.GithubRepositoryReference)
+    - [ListGithubRepositoriesRequest](#ddev.administration.v1alpha1.ListGithubRepositoriesRequest)
+    - [ListGithubRepositoriesResponse](#ddev.administration.v1alpha1.ListGithubRepositoriesResponse)
+    - [UpdateGithubIntegrationRequest](#ddev.administration.v1alpha1.UpdateGithubIntegrationRequest)
+    - [UpdateGithubIntegrationResponse](#ddev.administration.v1alpha1.UpdateGithubIntegrationResponse)
+  
 - [Scalar Value Types](#scalar-value-types)
-
-
-
-<a name="live/administration/v1alpha1/workspace.proto"></a>
-<p align="right"><a href="#top">Top</a></p>
-
-## live/administration/v1alpha1/workspace.proto
-
-
-
-<a name="ddev.administration.v1alpha1.AddWorkspaceAdminRequest"></a>
-
-### AddWorkspaceAdminRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [string](#string) |  | `Required` The name of the workspace to add this administrator to. |
-| email | [string](#string) |  | `Required` The email of the workspace administrator |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.AddWorkspaceAdminResponse"></a>
-
-### AddWorkspaceAdminResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest"></a>
-
-### AddWorkspaceDeveloperRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [string](#string) |  | `Required` The name of the workspace to add this developer to. |
-| email | [string](#string) |  | `Required` The email of the workspace developer. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse"></a>
-
-### AddWorkspaceDeveloperResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest"></a>
-
-### DeleteWorkspaceAdminRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [string](#string) |  | `Required` The name of the workspace to remove this administrator from. |
-| email | [string](#string) |  | `Required` The email of the workspace administrator. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse"></a>
-
-### DeleteWorkspaceAdminResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest"></a>
-
-### DeleteWorkspaceDeveloperRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [string](#string) |  | `Required` The name of the workspace to remove this developer from. |
-| email | [string](#string) |  | `Required` The email of the workspace developer. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse"></a>
-
-### DeleteWorkspaceDeveloperResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListWorkspaceRequest"></a>
-
-### ListWorkspaceRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| Scope | [ListWorkspaceRequest.ListWorkspaceScope](#ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope) |  | `Optional` The scope of the list request. Defaults to `ListWorkspaceScope.DEVELOPER`. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListWorkspaceResponse"></a>
-
-### ListWorkspaceResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspaces | [Workspace](#ddev.administration.v1alpha1.Workspace) | repeated | `OutputOnly` - A workspace for the current user |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.Workspace"></a>
-
-### Workspace
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | `OutputOnly` Workspace Name. |
-| admins | [string](#string) | repeated | `OutputOnly` Administrators of the workspace |
-| developers | [string](#string) | repeated | `OutputOnly` Developers in the workspace |
-| subscription | [string](#string) |  | The ID of the subscription which this workspace belongs |
-
-
-
-
-
- 
-
-
-<a name="ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope"></a>
-
-### ListWorkspaceRequest.ListWorkspaceScope
-Defines the scope of the request.  If the scope is set to ADMIN the response will contain only workspaces where the provided token user is an administrator.
-If the request is set to DEVELOPER the response will contain any workspace where the provided token user is an administrator or a developer.
-
-| Name | Number | Description |
-| ---- | ------ | ----------- |
-| DEVELOPER | 0 |  |
-| ADMIN | 1 |  |
-
-
- 
-
- 
-
- 
-
-
-
-<a name="live/administration/v1alpha1/githubintegration.proto"></a>
-<p align="right"><a href="#top">Top</a></p>
-
-## live/administration/v1alpha1/githubintegration.proto
-
-
-
-<a name="ddev.administration.v1alpha1.CreateGithubIntegrationRequest"></a>
-
-### CreateGithubIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The new GithubIntegration resource |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.CreateGithubIntegrationResponse"></a>
-
-### CreateGithubIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The new GithubIntegration resource |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteGithubIntegrationRequest"></a>
-
-### DeleteGithubIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The deleted GithubIntegration resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteGithubIntegrationResponse"></a>
-
-### DeleteGithubIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The deleted GithubIntegration resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GetRepositoryMetadataRequest"></a>
-
-### GetRepositoryMetadataRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `Required` The Repository ID. |
-| owner | [string](#string) |  | `Optional` The Repository owner. |
-| name | [string](#string) |  | `Optional` The Repository name. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GetRepositoryMetadataResponse"></a>
-
-### GetRepositoryMetadataResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `OutputOnly` The Repository ID. |
-| owner | [string](#string) |  | `OutputOnly` The Repository owner. |
-| name | [string](#string) |  | `OutputOnly` The Repository name. |
-| meta | [GithubRepositoryReference](#ddev.administration.v1alpha1.GithubRepositoryReference) | repeated | `OutputOnly` The Repository metadata. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubIntegrationRequest"></a>
-
-### GithubIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| installationID | [int64](#int64) |  | `Required` Installation ID. |
-| githubAppID | [int64](#int64) |  | `Required` Github App ID. |
-| githubAppSlug | [string](#string) |  | `Optional` Github App Slug. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubIntegrationResponse"></a>
-
-### GithubIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| installationID | [int64](#int64) |  | `Required` Installation ID. |
-| githubAppID | [int64](#int64) |  | `Required` Github App ID. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubRepositoryName"></a>
-
-### GithubRepositoryName
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `OutputOnly` The Repository ID. |
-| name | [string](#string) |  | `OutputOnly` The Repository name. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubRepositoryOwner"></a>
-
-### GithubRepositoryOwner
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | `OutputOnly` The Owner name. |
-| repositories | [GithubRepositoryName](#ddev.administration.v1alpha1.GithubRepositoryName) | repeated | `OutputOnly` List of Repository Names for this Owner. |
-| installationID | [string](#string) |  | `OutputOnly` The Installation ID of this Owner&#39;s GitHub App installation. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GithubRepositoryReference"></a>
-
-### GithubRepositoryReference
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| sha | [string](#string) |  | `OutputOnly` Reference commit sha. |
-| branch | [string](#string) |  |  |
-| tag | [string](#string) |  |  |
-| pullrequest | [string](#string) |  |  |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListGithubRepositoriesRequest"></a>
-
-### ListGithubRepositoriesRequest
-
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListGithubRepositoriesResponse"></a>
-
-### ListGithubRepositoriesResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| items | [GithubRepositoryOwner](#ddev.administration.v1alpha1.GithubRepositoryOwner) | repeated | `OutputOnly` Github repositories available to the user. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.UpdateGithubIntegrationRequest"></a>
-
-### UpdateGithubIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The updated GithubIntegration resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.UpdateGithubIntegrationResponse"></a>
-
-### UpdateGithubIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The updated GithubIntegration resource. |
-
-
-
-
-
- 
-
- 
-
- 
-
- 
-
-
-
-<a name="live/administration/v1alpha1/gitlabintegration.proto"></a>
-<p align="right"><a href="#top">Top</a></p>
-
-## live/administration/v1alpha1/gitlabintegration.proto
-
-
-
-<a name="ddev.administration.v1alpha1.CreateGitlabIntegrationRequest"></a>
-
-### CreateGitlabIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `Required` Gitlab integration ID. |
-| host | [string](#string) |  | `Required` Gitlab server URL. |
-| username | [string](#string) |  | `Required` Username for the token. |
-| token | [string](#string) |  | `Required` Gitlab Personal Access Token. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.CreateGitlabIntegrationResponse"></a>
-
-### CreateGitlabIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) |  | `OutputOnly` The new GitlabIntegration resource |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteGitlabIntegrationRequest"></a>
-
-### DeleteGitlabIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `Required` Gitlab integration ID. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.DeleteGitlabIntegrationResponse"></a>
-
-### DeleteGitlabIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) |  | `OutputOnly` The deleted GitlabIntegration resource. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GetGitlabIntegrationRequest"></a>
-
-### GetGitlabIntegrationRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `Required` Gitlab integration ID. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GetGitlabIntegrationResponse"></a>
-
-### GetGitlabIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integration | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) |  | `OutputOnly` Gitlab integration. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GetGitlabProjectMetadataRequest"></a>
-
-### GetGitlabProjectMetadataRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integrationID | [string](#string) |  | `Required` Integration ID. |
-| projectID | [string](#string) |  | `Required` Project ID. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GetGitlabProjectMetadataResponse"></a>
-
-### GetGitlabProjectMetadataResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `OutputOnly` The Project ID. |
-| meta | [GitlabProjectReference](#ddev.administration.v1alpha1.GitlabProjectReference) | repeated | `OutputOnly` The Project metadata. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GitlabIntegration"></a>
-
-### GitlabIntegration
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `OutputOnly` Gitlab integration ID. |
-| owners | [GitlabProjectOwner](#ddev.administration.v1alpha1.GitlabProjectOwner) | repeated | `OutputOnly` Gitlab projects available to the user. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GitlabIntegrationResponse"></a>
-
-### GitlabIntegrationResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `OutputOnly` Gitlab integration ID. |
-| host | [string](#string) |  | `OutputOnly` Gitlab server URL. |
-| username | [string](#string) |  | `OutputOnly` Username for the token. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GitlabProjectName"></a>
-
-### GitlabProjectName
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `OutputOnly` The Project ID. |
-| name | [string](#string) |  | `OutputOnly` The Project name. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GitlabProjectOwner"></a>
-
-### GitlabProjectOwner
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | `OutputOnly` Gitlab account username. |
-| projects | [GitlabProjectName](#ddev.administration.v1alpha1.GitlabProjectName) | repeated | `OutputOnly` List of Project Names for this Owner. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.GitlabProjectReference"></a>
-
-### GitlabProjectReference
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| sha | [string](#string) |  | `OutputOnly` Reference commit sha. |
-| ref | [string](#string) |  | `OutputOnly` Reference type. |
-| type | [ReferenceType](#ddev.administration.v1alpha1.ReferenceType) |  | `OutputOnly` Reference type (branch, tag, mr). |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListGitlabIntegrationsRequest"></a>
-
-### ListGitlabIntegrationsRequest
-
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListGitlabIntegrationsResponse"></a>
-
-### ListGitlabIntegrationsResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integrations | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) | repeated | `OutputOnly` Gitlab integrations. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListGitlabProjectsRequest"></a>
-
-### ListGitlabProjectsRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  | `Optional` Gitlab integration ID. |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ListGitlabProjectsResponse"></a>
-
-### ListGitlabProjectsResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| integrations | [GitlabIntegration](#ddev.administration.v1alpha1.GitlabIntegration) | repeated | `OutputOnly` Gitlab integrations available to the user. |
-
-
-
-
-
- 
-
-
-<a name="ddev.administration.v1alpha1.ReferenceType"></a>
-
-### ReferenceType
-
-
-| Name | Number | Description |
-| ---- | ------ | ----------- |
-| Branch | 0 |  |
-| Tag | 1 |  |
-| MR | 2 |  |
-
-
- 
-
- 
-
- 
 
 
 
@@ -1177,6 +437,7 @@ issued by the API.  This can be the integration token provided on the dashboard 
 | AddWorkspaceDeveloper | [AddWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest) | [AddWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse) | Add a developer to a workspace. Requires a workspace administrator token. |
 | DeleteWorkspaceAdmin | [DeleteWorkspaceAdminRequest](#ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest) | [DeleteWorkspaceAdminResponse](#ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse) | Remove an administrator from a workspace. Requires a workspace administrator token. An administrator cannot remove themselves. |
 | DeleteWorkspaceDeveloper | [DeleteWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest) | [DeleteWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse) | Remove a developer from a workspace. Requires a workspace administrator token. |
+| SetDefaultWorkspace | [SetDefaultWorkspaceRequest](#ddev.administration.v1alpha1.SetDefaultWorkspaceRequest) | [SetDefaultWorkspaceResponse](#ddev.administration.v1alpha1.SetDefaultWorkspaceResponse) | Updates a users current default workspace. |
 | IsAuthTokenViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can read the API scopes a user has. |
 | IsAuthTokenEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can issue different API access scopes within an organization |
 | IsBillingViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can access billing artifacts such as invoices |
@@ -1201,6 +462,779 @@ issued by the API.  This can be the integration token provided on the dashboard 
 | ListGitlabProjects | [ListGitlabProjectsRequest](#ddev.administration.v1alpha1.ListGitlabProjectsRequest) | [ListGitlabProjectsResponse](#ddev.administration.v1alpha1.ListGitlabProjectsResponse) | List gitlab projects |
 | GetGitlabProjectMetadata | [GetGitlabProjectMetadataRequest](#ddev.administration.v1alpha1.GetGitlabProjectMetadataRequest) | [GetGitlabProjectMetadataResponse](#ddev.administration.v1alpha1.GetGitlabProjectMetadataResponse) | Returns metadata of a Gitlab project by ID |
 | GetRepositoryMetadata | [GetRepositoryMetadataRequest](#ddev.administration.v1alpha1.GetRepositoryMetadataRequest) | [GetRepositoryMetadataResponse](#ddev.administration.v1alpha1.GetRepositoryMetadataResponse) | Returns metadata of a repository by ID |
+
+ 
+
+
+
+<a name="live/administration/v1alpha1/workspace.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## live/administration/v1alpha1/workspace.proto
+
+
+
+<a name="ddev.administration.v1alpha1.AddWorkspaceAdminRequest"></a>
+
+### AddWorkspaceAdminRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [string](#string) |  | `Required` The name of the workspace to add this administrator to. |
+| email | [string](#string) |  | `Required` The email of the workspace administrator |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.AddWorkspaceAdminResponse"></a>
+
+### AddWorkspaceAdminResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.AddWorkspaceDeveloperRequest"></a>
+
+### AddWorkspaceDeveloperRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [string](#string) |  | `Required` The name of the workspace to add this developer to. |
+| email | [string](#string) |  | `Required` The email of the workspace developer. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.AddWorkspaceDeveloperResponse"></a>
+
+### AddWorkspaceDeveloperResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest"></a>
+
+### DeleteWorkspaceAdminRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [string](#string) |  | `Required` The name of the workspace to remove this administrator from. |
+| email | [string](#string) |  | `Required` The email of the workspace administrator. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse"></a>
+
+### DeleteWorkspaceAdminResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest"></a>
+
+### DeleteWorkspaceDeveloperRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [string](#string) |  | `Required` The name of the workspace to remove this developer from. |
+| email | [string](#string) |  | `Required` The email of the workspace developer. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse"></a>
+
+### DeleteWorkspaceDeveloperResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListWorkspaceRequest"></a>
+
+### ListWorkspaceRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| Scope | [ListWorkspaceRequest.ListWorkspaceScope](#ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope) |  | `Optional` The scope of the list request. Defaults to `ListWorkspaceScope.DEVELOPER`. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListWorkspaceResponse"></a>
+
+### ListWorkspaceResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspaces | [Workspace](#ddev.administration.v1alpha1.Workspace) | repeated | `OutputOnly` - A workspace for the current user |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.SetDefaultWorkspaceRequest"></a>
+
+### SetDefaultWorkspaceRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| subscription | [string](#string) |  | `Required` The id of the subscription for the workspace |
+| workspace | [string](#string) |  | The name of the workspace in the subscription |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.SetDefaultWorkspaceResponse"></a>
+
+### SetDefaultWorkspaceResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The users default workspace |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.Workspace"></a>
+
+### Workspace
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | `OutputOnly` Workspace Name. |
+| admins | [string](#string) | repeated | `OutputOnly` Administrators of the workspace |
+| developers | [string](#string) | repeated | `OutputOnly` Developers in the workspace |
+| subscription | [string](#string) |  | The ID of the subscription which this workspace belongs |
+
+
+
+
+
+ 
+
+
+<a name="ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope"></a>
+
+### ListWorkspaceRequest.ListWorkspaceScope
+Defines the scope of the request.  If the scope is set to ADMIN the response will contain only workspaces where the provided token user is an administrator.
+If the request is set to DEVELOPER the response will contain any workspace where the provided token user is an administrator or a developer.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| DEVELOPER | 0 |  |
+| ADMIN | 1 |  |
+
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="live/administration/v1alpha1/gitlabintegration.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## live/administration/v1alpha1/gitlabintegration.proto
+
+
+
+<a name="ddev.administration.v1alpha1.CreateGitlabIntegrationRequest"></a>
+
+### CreateGitlabIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `Required` Gitlab integration ID. |
+| host | [string](#string) |  | `Required` Gitlab server URL. |
+| username | [string](#string) |  | `Required` Username for the token. |
+| token | [string](#string) |  | `Required` Gitlab Personal Access Token. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.CreateGitlabIntegrationResponse"></a>
+
+### CreateGitlabIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) |  | `OutputOnly` The new GitlabIntegration resource |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteGitlabIntegrationRequest"></a>
+
+### DeleteGitlabIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `Required` Gitlab integration ID. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteGitlabIntegrationResponse"></a>
+
+### DeleteGitlabIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) |  | `OutputOnly` The deleted GitlabIntegration resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetGitlabIntegrationRequest"></a>
+
+### GetGitlabIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `Required` Gitlab integration ID. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetGitlabIntegrationResponse"></a>
+
+### GetGitlabIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) |  | `OutputOnly` Gitlab integration. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetGitlabProjectMetadataRequest"></a>
+
+### GetGitlabProjectMetadataRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integrationID | [string](#string) |  | `Required` Integration ID. |
+| projectID | [string](#string) |  | `Required` Project ID. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetGitlabProjectMetadataResponse"></a>
+
+### GetGitlabProjectMetadataResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `OutputOnly` The Project ID. |
+| meta | [GitlabProjectReference](#ddev.administration.v1alpha1.GitlabProjectReference) | repeated | `OutputOnly` The Project metadata. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GitlabIntegration"></a>
+
+### GitlabIntegration
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `OutputOnly` Gitlab integration ID. |
+| owners | [GitlabProjectOwner](#ddev.administration.v1alpha1.GitlabProjectOwner) | repeated | `OutputOnly` Gitlab projects available to the user. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GitlabIntegrationResponse"></a>
+
+### GitlabIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `OutputOnly` Gitlab integration ID. |
+| host | [string](#string) |  | `OutputOnly` Gitlab server URL. |
+| username | [string](#string) |  | `OutputOnly` Username for the token. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GitlabProjectName"></a>
+
+### GitlabProjectName
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `OutputOnly` The Project ID. |
+| name | [string](#string) |  | `OutputOnly` The Project name. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GitlabProjectOwner"></a>
+
+### GitlabProjectOwner
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | `OutputOnly` Gitlab account username. |
+| projects | [GitlabProjectName](#ddev.administration.v1alpha1.GitlabProjectName) | repeated | `OutputOnly` List of Project Names for this Owner. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GitlabProjectReference"></a>
+
+### GitlabProjectReference
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| sha | [string](#string) |  | `OutputOnly` Reference commit sha. |
+| ref | [string](#string) |  | `OutputOnly` Reference type. |
+| type | [ReferenceType](#ddev.administration.v1alpha1.ReferenceType) |  | `OutputOnly` Reference type (branch, tag, mr). |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListGitlabIntegrationsRequest"></a>
+
+### ListGitlabIntegrationsRequest
+
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListGitlabIntegrationsResponse"></a>
+
+### ListGitlabIntegrationsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integrations | [GitlabIntegrationResponse](#ddev.administration.v1alpha1.GitlabIntegrationResponse) | repeated | `OutputOnly` Gitlab integrations. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListGitlabProjectsRequest"></a>
+
+### ListGitlabProjectsRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `Optional` Gitlab integration ID. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListGitlabProjectsResponse"></a>
+
+### ListGitlabProjectsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integrations | [GitlabIntegration](#ddev.administration.v1alpha1.GitlabIntegration) | repeated | `OutputOnly` Gitlab integrations available to the user. |
+
+
+
+
+
+ 
+
+
+<a name="ddev.administration.v1alpha1.ReferenceType"></a>
+
+### ReferenceType
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| Branch | 0 |  |
+| Tag | 1 |  |
+| MR | 2 |  |
+
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="live/administration/v1alpha1/githubintegration.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## live/administration/v1alpha1/githubintegration.proto
+
+
+
+<a name="ddev.administration.v1alpha1.CreateGithubIntegrationRequest"></a>
+
+### CreateGithubIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The new GithubIntegration resource |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.CreateGithubIntegrationResponse"></a>
+
+### CreateGithubIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The new GithubIntegration resource |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteGithubIntegrationRequest"></a>
+
+### DeleteGithubIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The deleted GithubIntegration resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.DeleteGithubIntegrationResponse"></a>
+
+### DeleteGithubIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The deleted GithubIntegration resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetRepositoryMetadataRequest"></a>
+
+### GetRepositoryMetadataRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `Required` The Repository ID. |
+| owner | [string](#string) |  | `Optional` The Repository owner. |
+| name | [string](#string) |  | `Optional` The Repository name. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetRepositoryMetadataResponse"></a>
+
+### GetRepositoryMetadataResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `OutputOnly` The Repository ID. |
+| owner | [string](#string) |  | `OutputOnly` The Repository owner. |
+| name | [string](#string) |  | `OutputOnly` The Repository name. |
+| meta | [GithubRepositoryReference](#ddev.administration.v1alpha1.GithubRepositoryReference) | repeated | `OutputOnly` The Repository metadata. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubIntegrationRequest"></a>
+
+### GithubIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| installationID | [int64](#int64) |  | `Required` Installation ID. |
+| githubAppID | [int64](#int64) |  | `Required` Github App ID. |
+| githubAppSlug | [string](#string) |  | `Optional` Github App Slug. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubIntegrationResponse"></a>
+
+### GithubIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| installationID | [int64](#int64) |  | `Required` Installation ID. |
+| githubAppID | [int64](#int64) |  | `Required` Github App ID. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubRepositoryName"></a>
+
+### GithubRepositoryName
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | `OutputOnly` The Repository ID. |
+| name | [string](#string) |  | `OutputOnly` The Repository name. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubRepositoryOwner"></a>
+
+### GithubRepositoryOwner
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | `OutputOnly` The Owner name. |
+| repositories | [GithubRepositoryName](#ddev.administration.v1alpha1.GithubRepositoryName) | repeated | `OutputOnly` List of Repository Names for this Owner. |
+| installationID | [string](#string) |  | `OutputOnly` The Installation ID of this Owner&#39;s GitHub App installation. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GithubRepositoryReference"></a>
+
+### GithubRepositoryReference
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| sha | [string](#string) |  | `OutputOnly` Reference commit sha. |
+| branch | [string](#string) |  |  |
+| tag | [string](#string) |  |  |
+| pullrequest | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListGithubRepositoriesRequest"></a>
+
+### ListGithubRepositoriesRequest
+
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ListGithubRepositoriesResponse"></a>
+
+### ListGithubRepositoriesResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| items | [GithubRepositoryOwner](#ddev.administration.v1alpha1.GithubRepositoryOwner) | repeated | `OutputOnly` Github repositories available to the user. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.UpdateGithubIntegrationRequest"></a>
+
+### UpdateGithubIntegrationRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationRequest](#ddev.administration.v1alpha1.GithubIntegrationRequest) |  | `Required` The updated GithubIntegration resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.UpdateGithubIntegrationResponse"></a>
+
+### UpdateGithubIntegrationResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| integration | [GithubIntegrationResponse](#ddev.administration.v1alpha1.GithubIntegrationResponse) |  | `OutputOnly` The updated GithubIntegration resource. |
+
+
+
+
+
+ 
+
+ 
+
+ 
 
  
 

--- a/doc/api/administration-api.md
+++ b/doc/api/administration-api.md
@@ -39,13 +39,14 @@
     - [DeleteWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse)
     - [GetDefaultWorkspaceRequest](#ddev.administration.v1alpha1.GetDefaultWorkspaceRequest)
     - [GetDefaultWorkspaceResponse](#ddev.administration.v1alpha1.GetDefaultWorkspaceResponse)
+    - [GetWorkspaceRequest](#ddev.administration.v1alpha1.GetWorkspaceRequest)
+    - [GetWorkspaceResponse](#ddev.administration.v1alpha1.GetWorkspaceResponse)
     - [ListWorkspaceRequest](#ddev.administration.v1alpha1.ListWorkspaceRequest)
     - [ListWorkspaceResponse](#ddev.administration.v1alpha1.ListWorkspaceResponse)
-    - [ResolveWorkspaceRequest](#ddev.administration.v1alpha1.ResolveWorkspaceRequest)
-    - [ResolveWorkspaceResponse](#ddev.administration.v1alpha1.ResolveWorkspaceResponse)
     - [SetDefaultWorkspaceRequest](#ddev.administration.v1alpha1.SetDefaultWorkspaceRequest)
     - [SetDefaultWorkspaceResponse](#ddev.administration.v1alpha1.SetDefaultWorkspaceResponse)
     - [Workspace](#ddev.administration.v1alpha1.Workspace)
+    - [Workspace.MetadataEntry](#ddev.administration.v1alpha1.Workspace.MetadataEntry)
   
     - [ListWorkspaceRequest.ListWorkspaceScope](#ddev.administration.v1alpha1.ListWorkspaceRequest.ListWorkspaceScope)
   
@@ -443,7 +444,7 @@ issued by the API.  This can be the integration token provided on the dashboard 
 | DeleteWorkspaceDeveloper | [DeleteWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest) | [DeleteWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse) | Remove a developer from a workspace. Requires a workspace administrator token. |
 | SetDefaultWorkspace | [SetDefaultWorkspaceRequest](#ddev.administration.v1alpha1.SetDefaultWorkspaceRequest) | [SetDefaultWorkspaceResponse](#ddev.administration.v1alpha1.SetDefaultWorkspaceResponse) | Updates a users current default workspace. |
 | GetDefaultWorkspace | [GetDefaultWorkspaceRequest](#ddev.administration.v1alpha1.GetDefaultWorkspaceRequest) | [GetDefaultWorkspaceResponse](#ddev.administration.v1alpha1.GetDefaultWorkspaceResponse) | Gets a users current default workspace. A users default workspace is specified in the JWT which they carry, however this may not be as up to date as their user record. If a user was to, for example, generate a new token and then set their default workspace their token would reflect their previous default until it is reissued. |
-| ResolveWorkspace | [ResolveWorkspaceRequest](#ddev.administration.v1alpha1.ResolveWorkspaceRequest) | [ResolveWorkspaceResponse](#ddev.administration.v1alpha1.ResolveWorkspaceResponse) | `Deprecated` User workspaces are qualified by their subscription. Resolve workspace will attempt to resolve a users fully qualified workspace name from its short name. |
+| GetWorkspace | [GetWorkspaceRequest](#ddev.administration.v1alpha1.GetWorkspaceRequest) | [GetWorkspaceResponse](#ddev.administration.v1alpha1.GetWorkspaceResponse) | `Deprecated` User workspaces are qualified by their subscription. Resolve workspace will attempt to resolve a users fully qualified workspace name from its short name. |
 | IsAuthTokenViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can read the API scopes a user has. |
 | IsAuthTokenEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can issue different API access scopes within an organization |
 | IsBillingViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can access billing artifacts such as invoices |
@@ -633,6 +634,36 @@ issued by the API.  This can be the integration token provided on the dashboard 
 
 
 
+<a name="ddev.administration.v1alpha1.GetWorkspaceRequest"></a>
+
+### GetWorkspaceRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | `Required` The desired workspace name |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetWorkspaceResponse"></a>
+
+### GetWorkspaceResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The name of the workspace best passed into the auth server |
+
+
+
+
+
+
 <a name="ddev.administration.v1alpha1.ListWorkspaceRequest"></a>
 
 ### ListWorkspaceRequest
@@ -657,36 +688,6 @@ issued by the API.  This can be the integration token provided on the dashboard 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | workspaces | [Workspace](#ddev.administration.v1alpha1.Workspace) | repeated | `OutputOnly` - A workspace for the current user |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ResolveWorkspaceRequest"></a>
-
-### ResolveWorkspaceRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| shortname | [string](#string) |  | `Required` The desired workspace name |
-
-
-
-
-
-
-<a name="ddev.administration.v1alpha1.ResolveWorkspaceResponse"></a>
-
-### ResolveWorkspaceResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| workspace | [string](#string) |  | `OutputOnly` The name of the workspace best passed into the auth server |
 
 
 
@@ -736,6 +737,23 @@ issued by the API.  This can be the integration token provided on the dashboard 
 | admins | [string](#string) | repeated | `OutputOnly` Administrators of the workspace |
 | developers | [string](#string) | repeated | `OutputOnly` Developers in the workspace |
 | subscription | [string](#string) |  | The ID of the subscription which this workspace belongs |
+| metadata | [Workspace.MetadataEntry](#ddev.administration.v1alpha1.Workspace.MetadataEntry) | repeated | Optional metadata information about this workspace |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.Workspace.MetadataEntry"></a>
+
+### Workspace.MetadataEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
 
 
 

--- a/doc/api/administration-api.md
+++ b/doc/api/administration-api.md
@@ -37,6 +37,8 @@
     - [DeleteWorkspaceAdminResponse](#ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse)
     - [DeleteWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest)
     - [DeleteWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse)
+    - [GetDefaultWorkspaceRequest](#ddev.administration.v1alpha1.GetDefaultWorkspaceRequest)
+    - [GetDefaultWorkspaceResponse](#ddev.administration.v1alpha1.GetDefaultWorkspaceResponse)
     - [ListWorkspaceRequest](#ddev.administration.v1alpha1.ListWorkspaceRequest)
     - [ListWorkspaceResponse](#ddev.administration.v1alpha1.ListWorkspaceResponse)
     - [SetDefaultWorkspaceRequest](#ddev.administration.v1alpha1.SetDefaultWorkspaceRequest)
@@ -438,6 +440,7 @@ issued by the API.  This can be the integration token provided on the dashboard 
 | DeleteWorkspaceAdmin | [DeleteWorkspaceAdminRequest](#ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest) | [DeleteWorkspaceAdminResponse](#ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse) | Remove an administrator from a workspace. Requires a workspace administrator token. An administrator cannot remove themselves. |
 | DeleteWorkspaceDeveloper | [DeleteWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest) | [DeleteWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse) | Remove a developer from a workspace. Requires a workspace administrator token. |
 | SetDefaultWorkspace | [SetDefaultWorkspaceRequest](#ddev.administration.v1alpha1.SetDefaultWorkspaceRequest) | [SetDefaultWorkspaceResponse](#ddev.administration.v1alpha1.SetDefaultWorkspaceResponse) | Updates a users current default workspace. |
+| GetDefaultWorkspace | [GetDefaultWorkspaceRequest](#ddev.administration.v1alpha1.GetDefaultWorkspaceRequest) | [GetDefaultWorkspaceResponse](#ddev.administration.v1alpha1.GetDefaultWorkspaceResponse) | Updates a users current default workspace. |
 | IsAuthTokenViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can read the API scopes a user has. |
 | IsAuthTokenEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can issue different API access scopes within an organization |
 | IsBillingViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can access billing artifacts such as invoices |
@@ -484,6 +487,7 @@ issued by the API.  This can be the integration token provided on the dashboard 
 | ----- | ---- | ----- | ----------- |
 | workspace | [string](#string) |  | `Required` The name of the workspace to add this administrator to. |
 | email | [string](#string) |  | `Required` The email of the workspace administrator |
+| subscription | [string](#string) |  | `Required` The subscription to which the workspace belongs |
 
 
 
@@ -515,6 +519,7 @@ issued by the API.  This can be the integration token provided on the dashboard 
 | ----- | ---- | ----- | ----------- |
 | workspace | [string](#string) |  | `Required` The name of the workspace to add this developer to. |
 | email | [string](#string) |  | `Required` The email of the workspace developer. |
+| subscription | [string](#string) |  | `Required` The subscription to which the workspace belongs |
 
 
 
@@ -546,6 +551,7 @@ issued by the API.  This can be the integration token provided on the dashboard 
 | ----- | ---- | ----- | ----------- |
 | workspace | [string](#string) |  | `Required` The name of the workspace to remove this administrator from. |
 | email | [string](#string) |  | `Required` The email of the workspace administrator. |
+| subscription | [string](#string) |  | `Required` The subscription to which the workspace belongs |
 
 
 
@@ -577,6 +583,7 @@ issued by the API.  This can be the integration token provided on the dashboard 
 | ----- | ---- | ----- | ----------- |
 | workspace | [string](#string) |  | `Required` The name of the workspace to remove this developer from. |
 | email | [string](#string) |  | `Required` The email of the workspace developer. |
+| subscription | [string](#string) |  | `Required` The subscription to which the workspace belongs |
 
 
 
@@ -592,6 +599,31 @@ issued by the API.  This can be the integration token provided on the dashboard 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | workspace | [Workspace](#ddev.administration.v1alpha1.Workspace) |  | `OutputOnly` The updated workspace resource. |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetDefaultWorkspaceRequest"></a>
+
+### GetDefaultWorkspaceRequest
+
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.GetDefaultWorkspaceResponse"></a>
+
+### GetDefaultWorkspaceResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [string](#string) |  | `OutputOnly` The callers default workspace |
 
 
 

--- a/doc/api/administration-api.md
+++ b/doc/api/administration-api.md
@@ -41,6 +41,8 @@
     - [GetDefaultWorkspaceResponse](#ddev.administration.v1alpha1.GetDefaultWorkspaceResponse)
     - [ListWorkspaceRequest](#ddev.administration.v1alpha1.ListWorkspaceRequest)
     - [ListWorkspaceResponse](#ddev.administration.v1alpha1.ListWorkspaceResponse)
+    - [ResolveWorkspaceRequest](#ddev.administration.v1alpha1.ResolveWorkspaceRequest)
+    - [ResolveWorkspaceResponse](#ddev.administration.v1alpha1.ResolveWorkspaceResponse)
     - [SetDefaultWorkspaceRequest](#ddev.administration.v1alpha1.SetDefaultWorkspaceRequest)
     - [SetDefaultWorkspaceResponse](#ddev.administration.v1alpha1.SetDefaultWorkspaceResponse)
     - [Workspace](#ddev.administration.v1alpha1.Workspace)
@@ -440,7 +442,8 @@ issued by the API.  This can be the integration token provided on the dashboard 
 | DeleteWorkspaceAdmin | [DeleteWorkspaceAdminRequest](#ddev.administration.v1alpha1.DeleteWorkspaceAdminRequest) | [DeleteWorkspaceAdminResponse](#ddev.administration.v1alpha1.DeleteWorkspaceAdminResponse) | Remove an administrator from a workspace. Requires a workspace administrator token. An administrator cannot remove themselves. |
 | DeleteWorkspaceDeveloper | [DeleteWorkspaceDeveloperRequest](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperRequest) | [DeleteWorkspaceDeveloperResponse](#ddev.administration.v1alpha1.DeleteWorkspaceDeveloperResponse) | Remove a developer from a workspace. Requires a workspace administrator token. |
 | SetDefaultWorkspace | [SetDefaultWorkspaceRequest](#ddev.administration.v1alpha1.SetDefaultWorkspaceRequest) | [SetDefaultWorkspaceResponse](#ddev.administration.v1alpha1.SetDefaultWorkspaceResponse) | Updates a users current default workspace. |
-| GetDefaultWorkspace | [GetDefaultWorkspaceRequest](#ddev.administration.v1alpha1.GetDefaultWorkspaceRequest) | [GetDefaultWorkspaceResponse](#ddev.administration.v1alpha1.GetDefaultWorkspaceResponse) | Updates a users current default workspace. |
+| GetDefaultWorkspace | [GetDefaultWorkspaceRequest](#ddev.administration.v1alpha1.GetDefaultWorkspaceRequest) | [GetDefaultWorkspaceResponse](#ddev.administration.v1alpha1.GetDefaultWorkspaceResponse) | Gets a users current default workspace. A users default workspace is specified in the JWT which they carry, however this may not be as up to date as their user record. If a user was to, for example, generate a new token and then set their default workspace their token would reflect their previous default until it is reissued. |
+| ResolveWorkspace | [ResolveWorkspaceRequest](#ddev.administration.v1alpha1.ResolveWorkspaceRequest) | [ResolveWorkspaceResponse](#ddev.administration.v1alpha1.ResolveWorkspaceResponse) | `Deprecated` User workspaces are qualified by their subscription. Resolve workspace will attempt to resolve a users fully qualified workspace name from its short name. |
 | IsAuthTokenViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can read the API scopes a user has. |
 | IsAuthTokenEditor | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can issue different API access scopes within an organization |
 | IsBillingViewer | [AuthorizationRequest](#ddev.administration.v1alpha1.AuthorizationRequest) | [AuthorizationResponse](#ddev.administration.v1alpha1.AuthorizationResponse) | Describes a permission which can access billing artifacts such as invoices |
@@ -654,6 +657,36 @@ issued by the API.  This can be the integration token provided on the dashboard 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | workspaces | [Workspace](#ddev.administration.v1alpha1.Workspace) | repeated | `OutputOnly` - A workspace for the current user |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ResolveWorkspaceRequest"></a>
+
+### ResolveWorkspaceRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| shortname | [string](#string) |  | `Required` The desired workspace name |
+
+
+
+
+
+
+<a name="ddev.administration.v1alpha1.ResolveWorkspaceResponse"></a>
+
+### ResolveWorkspaceResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [string](#string) |  | `OutputOnly` The name of the workspace best passed into the auth server |
 
 
 

--- a/doc/api/site-api.md
+++ b/doc/api/site-api.md
@@ -3,26 +3,6 @@
 
 ## Table of Contents
 
-- [live/sites/v1alpha1/metadata.proto](#live/sites/v1alpha1/metadata.proto)
-    - [Metadata](#ddev.sites.v1alpha1.Metadata)
-    - [Metadata.LabelsEntry](#ddev.sites.v1alpha1.Metadata.LabelsEntry)
-  
-- [live/sites/v1alpha1/database.proto](#live/sites/v1alpha1/database.proto)
-    - [BackupDatabaseRequest](#ddev.sites.v1alpha1.BackupDatabaseRequest)
-    - [BackupDatabaseResponse](#ddev.sites.v1alpha1.BackupDatabaseResponse)
-    - [DatabaseBackup](#ddev.sites.v1alpha1.DatabaseBackup)
-    - [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata)
-    - [ListDatabaseBackupsRequest](#ddev.sites.v1alpha1.ListDatabaseBackupsRequest)
-    - [ListDatabaseBackupsResponse](#ddev.sites.v1alpha1.ListDatabaseBackupsResponse)
-    - [PullDatabaseBackupRequest](#ddev.sites.v1alpha1.PullDatabaseBackupRequest)
-    - [PullDatabaseBackupResponse](#ddev.sites.v1alpha1.PullDatabaseBackupResponse)
-    - [PushDatabaseBackupRequest](#ddev.sites.v1alpha1.PushDatabaseBackupRequest)
-    - [PushDatabaseBackupResponse](#ddev.sites.v1alpha1.PushDatabaseBackupResponse)
-    - [RestoreDatabaseRequest](#ddev.sites.v1alpha1.RestoreDatabaseRequest)
-    - [RestoreDatabaseResponse](#ddev.sites.v1alpha1.RestoreDatabaseResponse)
-  
-    - [BackupState](#ddev.sites.v1alpha1.BackupState)
-  
 - [live/sites/v1alpha1/file.proto](#live/sites/v1alpha1/file.proto)
     - [BackupFilesRequest](#ddev.sites.v1alpha1.BackupFilesRequest)
     - [BackupFilesResponse](#ddev.sites.v1alpha1.BackupFilesResponse)
@@ -42,6 +22,26 @@
   
 - [live/sites/v1alpha1/service.proto](#live/sites/v1alpha1/service.proto)
     - [Sites](#ddev.sites.v1alpha1.Sites)
+  
+- [live/sites/v1alpha1/database.proto](#live/sites/v1alpha1/database.proto)
+    - [BackupDatabaseRequest](#ddev.sites.v1alpha1.BackupDatabaseRequest)
+    - [BackupDatabaseResponse](#ddev.sites.v1alpha1.BackupDatabaseResponse)
+    - [DatabaseBackup](#ddev.sites.v1alpha1.DatabaseBackup)
+    - [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata)
+    - [ListDatabaseBackupsRequest](#ddev.sites.v1alpha1.ListDatabaseBackupsRequest)
+    - [ListDatabaseBackupsResponse](#ddev.sites.v1alpha1.ListDatabaseBackupsResponse)
+    - [PullDatabaseBackupRequest](#ddev.sites.v1alpha1.PullDatabaseBackupRequest)
+    - [PullDatabaseBackupResponse](#ddev.sites.v1alpha1.PullDatabaseBackupResponse)
+    - [PushDatabaseBackupRequest](#ddev.sites.v1alpha1.PushDatabaseBackupRequest)
+    - [PushDatabaseBackupResponse](#ddev.sites.v1alpha1.PushDatabaseBackupResponse)
+    - [RestoreDatabaseRequest](#ddev.sites.v1alpha1.RestoreDatabaseRequest)
+    - [RestoreDatabaseResponse](#ddev.sites.v1alpha1.RestoreDatabaseResponse)
+  
+    - [BackupState](#ddev.sites.v1alpha1.BackupState)
+  
+- [live/sites/v1alpha1/metadata.proto](#live/sites/v1alpha1/metadata.proto)
+    - [Metadata](#ddev.sites.v1alpha1.Metadata)
+    - [Metadata.LabelsEntry](#ddev.sites.v1alpha1.Metadata.LabelsEntry)
   
 - [live/sites/v1alpha1/site.proto](#live/sites/v1alpha1/site.proto)
     - [AccessLogsRequest](#ddev.sites.v1alpha1.AccessLogsRequest)
@@ -91,272 +91,6 @@
     - [SiteType](#ddev.sites.v1alpha1.SiteType)
   
 - [Scalar Value Types](#scalar-value-types)
-
-
-
-<a name="live/sites/v1alpha1/metadata.proto"></a>
-<p align="right"><a href="#top">Top</a></p>
-
-## live/sites/v1alpha1/metadata.proto
-
-
-
-<a name="ddev.sites.v1alpha1.Metadata"></a>
-
-### Metadata
-Generic metadata about the object.
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| labels | [Metadata.LabelsEntry](#ddev.sites.v1alpha1.Metadata.LabelsEntry) | repeated | A map of labels set on the object |
-| created | [int64](#int64) |  | `OutputOnly` A unix timestamp which expresses the time in which this object was initially created. A zero value indicates that the timestamp has not been set. |
-| updated | [int64](#int64) |  | `OutputOnly` A unix timestamp which expresses the time in which this object was last updated. A zero value indicates that the timestamp has not been set. |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.Metadata.LabelsEntry"></a>
-
-### Metadata.LabelsEntry
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| key | [string](#string) |  |  |
-| value | [string](#string) |  |  |
-
-
-
-
-
- 
-
- 
-
- 
-
- 
-
-
-
-<a name="live/sites/v1alpha1/database.proto"></a>
-<p align="right"><a href="#top">Top</a></p>
-
-## live/sites/v1alpha1/database.proto
-
-
-
-<a name="ddev.sites.v1alpha1.BackupDatabaseRequest"></a>
-
-### BackupDatabaseRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| site | [string](#string) |  | `Required` The name of the site to backup. |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.BackupDatabaseResponse"></a>
-
-### BackupDatabaseResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| backup | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) |  | The state of the backup |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.DatabaseBackup"></a>
-
-### DatabaseBackup
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| metadata | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) |  | Metadata information about this backup |
-| content | [bytes](#bytes) |  | The raw bytes the the content. Supported MIME Types: `gz` |
-| CRC32c | [string](#string) |  | `Optional` CRC32c checksum of the data, as described in RFC 4960, Appendix B; encoded using base64 in big-endian byte order. In the event of streaming requests the CRC32c shall represent the checksum of the entire file. If provided a checksum mismatch will result in an error on the receiver. |
-| MD5 | [string](#string) |  | `Optional` MD5 hash of the data; encoded using base64. In the event of streaming requests the MD5 shall represent the checksum of the entire file. If provided a checksum mismatch will result in an error on the receiver. |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.DatabaseBackupMetadata"></a>
-
-### DatabaseBackupMetadata
-The backup object
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  | The name of the backup |
-| databaseReference | [string](#string) |  | The database this backup references |
-| created | [int64](#int64) |  | `OutputOnly` The unix timestamp in which this backup was taken |
-| state | [BackupState](#ddev.sites.v1alpha1.BackupState) |  | `OutputOnly` The state of this backup |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.ListDatabaseBackupsRequest"></a>
-
-### ListDatabaseBackupsRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| site | [string](#string) |  | `Required` The name of the site |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.ListDatabaseBackupsResponse"></a>
-
-### ListDatabaseBackupsResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| backup | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) | repeated | `OutputOnly` The metadata for all backup objects. |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.PullDatabaseBackupRequest"></a>
-
-### PullDatabaseBackupRequest
-Pull database pulls the state of a specified database backup
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| backup | [string](#string) |  | `Required` The name of the backup to pull. |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.PullDatabaseBackupResponse"></a>
-
-### PullDatabaseBackupResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| backup | [DatabaseBackup](#ddev.sites.v1alpha1.DatabaseBackup) |  | `OutputOnly` The backup object |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.PushDatabaseBackupRequest"></a>
-
-### PushDatabaseBackupRequest
-Push a single database to a site
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| site | [string](#string) |  | `Required` The name of the site to push to. |
-| backup | [DatabaseBackup](#ddev.sites.v1alpha1.DatabaseBackup) |  | The backup object |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.PushDatabaseBackupResponse"></a>
-
-### PushDatabaseBackupResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| backup | [string](#string) |  | The name of the restorable backup resource |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.RestoreDatabaseRequest"></a>
-
-### RestoreDatabaseRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| site | [string](#string) |  | `Required` The name of the site to restore. |
-| backup | [string](#string) |  | `Required` The name of the backup to restore the site to. |
-
-
-
-
-
-
-<a name="ddev.sites.v1alpha1.RestoreDatabaseResponse"></a>
-
-### RestoreDatabaseResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| backup | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) |  | The state of the backup |
-
-
-
-
-
- 
-
-
-<a name="ddev.sites.v1alpha1.BackupState"></a>
-
-### BackupState
-
-
-| Name | Number | Description |
-| ---- | ------ | ----------- |
-| CREATED | 0 |  |
-| FINISHED | 1 |  |
-| DELETED | 2 |  |
-
-
- 
-
- 
-
- 
 
 
 
@@ -667,6 +401,272 @@ several metadata to be passed to the client.
 | PullFileBackupStream | [PullFileBackupRequest](#ddev.sites.v1alpha1.PullFileBackupRequest) | [PullFileBackupResponse](#ddev.sites.v1alpha1.PullFileBackupResponse) stream | PullFileStream streams currently staged file[s] from the server and pulls them down to a local source |
 | DescribeFileBackup | [DescribeFileBackupRequest](#ddev.sites.v1alpha1.DescribeFileBackupRequest) | [DescribeFileBackupResponse](#ddev.sites.v1alpha1.DescribeFileBackupResponse) | DescribeFiles returns the metadata for current files staged for a restore operation |
 | ListFileBackups | [ListFileBackupsRequest](#ddev.sites.v1alpha1.ListFileBackupsRequest) | [ListFileBackupsResponse](#ddev.sites.v1alpha1.ListFileBackupsResponse) | Lists file backups known for a provided site |
+
+ 
+
+
+
+<a name="live/sites/v1alpha1/database.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## live/sites/v1alpha1/database.proto
+
+
+
+<a name="ddev.sites.v1alpha1.BackupDatabaseRequest"></a>
+
+### BackupDatabaseRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| site | [string](#string) |  | `Required` The name of the site to backup. |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.BackupDatabaseResponse"></a>
+
+### BackupDatabaseResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| backup | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) |  | The state of the backup |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.DatabaseBackup"></a>
+
+### DatabaseBackup
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| metadata | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) |  | Metadata information about this backup |
+| content | [bytes](#bytes) |  | The raw bytes the the content. Supported MIME Types: `gz` |
+| CRC32c | [string](#string) |  | `Optional` CRC32c checksum of the data, as described in RFC 4960, Appendix B; encoded using base64 in big-endian byte order. In the event of streaming requests the CRC32c shall represent the checksum of the entire file. If provided a checksum mismatch will result in an error on the receiver. |
+| MD5 | [string](#string) |  | `Optional` MD5 hash of the data; encoded using base64. In the event of streaming requests the MD5 shall represent the checksum of the entire file. If provided a checksum mismatch will result in an error on the receiver. |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.DatabaseBackupMetadata"></a>
+
+### DatabaseBackupMetadata
+The backup object
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  | The name of the backup |
+| databaseReference | [string](#string) |  | The database this backup references |
+| created | [int64](#int64) |  | `OutputOnly` The unix timestamp in which this backup was taken |
+| state | [BackupState](#ddev.sites.v1alpha1.BackupState) |  | `OutputOnly` The state of this backup |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.ListDatabaseBackupsRequest"></a>
+
+### ListDatabaseBackupsRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| site | [string](#string) |  | `Required` The name of the site |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.ListDatabaseBackupsResponse"></a>
+
+### ListDatabaseBackupsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| backup | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) | repeated | `OutputOnly` The metadata for all backup objects. |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.PullDatabaseBackupRequest"></a>
+
+### PullDatabaseBackupRequest
+Pull database pulls the state of a specified database backup
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| backup | [string](#string) |  | `Required` The name of the backup to pull. |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.PullDatabaseBackupResponse"></a>
+
+### PullDatabaseBackupResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| backup | [DatabaseBackup](#ddev.sites.v1alpha1.DatabaseBackup) |  | `OutputOnly` The backup object |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.PushDatabaseBackupRequest"></a>
+
+### PushDatabaseBackupRequest
+Push a single database to a site
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| site | [string](#string) |  | `Required` The name of the site to push to. |
+| backup | [DatabaseBackup](#ddev.sites.v1alpha1.DatabaseBackup) |  | The backup object |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.PushDatabaseBackupResponse"></a>
+
+### PushDatabaseBackupResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| backup | [string](#string) |  | The name of the restorable backup resource |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.RestoreDatabaseRequest"></a>
+
+### RestoreDatabaseRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| site | [string](#string) |  | `Required` The name of the site to restore. |
+| backup | [string](#string) |  | `Required` The name of the backup to restore the site to. |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.RestoreDatabaseResponse"></a>
+
+### RestoreDatabaseResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| backup | [DatabaseBackupMetadata](#ddev.sites.v1alpha1.DatabaseBackupMetadata) |  | The state of the backup |
+
+
+
+
+
+ 
+
+
+<a name="ddev.sites.v1alpha1.BackupState"></a>
+
+### BackupState
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| CREATED | 0 |  |
+| FINISHED | 1 |  |
+| DELETED | 2 |  |
+
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="live/sites/v1alpha1/metadata.proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## live/sites/v1alpha1/metadata.proto
+
+
+
+<a name="ddev.sites.v1alpha1.Metadata"></a>
+
+### Metadata
+Generic metadata about the object.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| labels | [Metadata.LabelsEntry](#ddev.sites.v1alpha1.Metadata.LabelsEntry) | repeated | A map of labels set on the object |
+| created | [int64](#int64) |  | `OutputOnly` A unix timestamp which expresses the time in which this object was initially created. A zero value indicates that the timestamp has not been set. |
+| updated | [int64](#int64) |  | `OutputOnly` A unix timestamp which expresses the time in which this object was last updated. A zero value indicates that the timestamp has not been set. |
+
+
+
+
+
+
+<a name="ddev.sites.v1alpha1.Metadata.LabelsEntry"></a>
+
+### Metadata.LabelsEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  |  |
+| value | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
 
  
 

--- a/live/administration/v1alpha1/BUILD.bazel
+++ b/live/administration/v1alpha1/BUILD.bazel
@@ -17,7 +17,7 @@ proto_library(
 go_proto_library(
     name = "v1alpha1_go_proto",
     compilers = ["@io_bazel_rules_go//proto:go_grpc"],
-    importpath = "github.com/drud/admin-api/gen/live/administration/v1alpha1",
+    importpath = "github.com/drud/ddev-apis-go/live/administration/v1alpha1",
     proto = ":v1alpha1_proto",
     visibility = ["//visibility:public"],
 )
@@ -25,6 +25,6 @@ go_proto_library(
 go_library(
     name = "go_default_library",
     embed = [":v1alpha1_go_proto"],
-    importpath = "github.com/drud/admin-api/gen/live/administration/v1alpha1",
+    importpath = "github.com/drud/ddev-apis-go/live/administration/v1alpha1",
     visibility = ["//visibility:public"],
 )

--- a/live/administration/v1alpha1/auth.proto
+++ b/live/administration/v1alpha1/auth.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package ddev.administration.v1alpha1;
 
-option go_package = "github.com/drud/admin-api/gen/live/administration/v1alpha1";
+option go_package = "github.com/drud/ddev-apis-go/live/administration/v1alpha1";
 option java_multiple_files = true;
 option java_outer_classname = "AuthProto";
 option java_package = "com.ddev.live.administration.v1alpha1";

--- a/live/administration/v1alpha1/githubintegration.proto
+++ b/live/administration/v1alpha1/githubintegration.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package ddev.administration.v1alpha1;
 
-option go_package = "github.com/drud/admin-api/gen/live/administration/v1alpha1";
+option go_package = "github.com/drud/ddev-apis-go/live/administration/v1alpha1";
 option java_multiple_files = true;
 option java_outer_classname = "GithubIntegrationProto";
 option java_package = "com.ddev.live.administration.v1alpha1";

--- a/live/administration/v1alpha1/gitlabintegration.proto
+++ b/live/administration/v1alpha1/gitlabintegration.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package ddev.administration.v1alpha1;
 
-option go_package = "github.com/drud/admin-api/gen/live/administration/v1alpha1";
+option go_package = "github.com/drud/ddev-apis-go/live/administration/v1alpha1";
 option java_multiple_files = true;
 option java_outer_classname = "GitlabIntegrationProto";
 option java_package = "com.ddev.live.administration.v1alpha1";

--- a/live/administration/v1alpha1/service.proto
+++ b/live/administration/v1alpha1/service.proto
@@ -21,7 +21,7 @@ import "live/administration/v1alpha1/workspace.proto";
 import "live/administration/v1alpha1/githubintegration.proto";
 import "live/administration/v1alpha1/gitlabintegration.proto";
 
-option go_package = "github.com/drud/admin-api/gen/live/administration/v1alpha1";
+option go_package = "github.com/drud/ddev-apis-go/live/administration/v1alpha1";
 option java_multiple_files = true;
 option java_outer_classname = "ServiceProto";
 option java_package = "com.ddev.live.administration.v1alpha1";

--- a/live/administration/v1alpha1/service.proto
+++ b/live/administration/v1alpha1/service.proto
@@ -118,6 +118,12 @@ service Administration {
     }
 
     /*
+    Updates a users current default workspace.
+    */
+    rpc GetDefaultWorkspace(GetDefaultWorkspaceRequest) returns (GetDefaultWorkspaceResponse) {
+    }
+
+    /*
     Helpers on parsing permissions from context metadata
     */
 

--- a/live/administration/v1alpha1/service.proto
+++ b/live/administration/v1alpha1/service.proto
@@ -112,6 +112,12 @@ service Administration {
     }
 
     /*
+    Updates a users current default workspace.
+    */
+    rpc SetDefaultWorkspace(SetDefaultWorkspaceRequest) returns (SetDefaultWorkspaceResponse) {
+    }
+
+    /*
     Helpers on parsing permissions from context metadata
     */
 

--- a/live/administration/v1alpha1/service.proto
+++ b/live/administration/v1alpha1/service.proto
@@ -127,7 +127,7 @@ service Administration {
     `Deprecated`
     User workspaces are qualified by their subscription.  Resolve workspace will attempt to resolve a users fully qualified workspace name from its short name.
     */
-    rpc ResolveWorkspace(ResolveWorkspaceRequest) returns (ResolveWorkspaceResponse) {
+    rpc GetWorkspace(GetWorkspaceRequest) returns (GetWorkspaceResponse) {
     }
 
     /*

--- a/live/administration/v1alpha1/service.proto
+++ b/live/administration/v1alpha1/service.proto
@@ -118,9 +118,16 @@ service Administration {
     }
 
     /*
-    Updates a users current default workspace.
+    Gets a users current default workspace.  A users default workspace is specified in the JWT which they carry, however this may not be as up to date as their user record.  If a user was to, for example, generate a new token and then set their default workspace their token would reflect their previous default until it is reissued.
     */
     rpc GetDefaultWorkspace(GetDefaultWorkspaceRequest) returns (GetDefaultWorkspaceResponse) {
+    }
+
+    /*
+    `Deprecated`
+    User workspaces are qualified by their subscription.  Resolve workspace will attempt to resolve a users fully qualified workspace name from its short name.
+    */
+    rpc ResolveWorkspace(ResolveWorkspaceRequest) returns (ResolveWorkspaceResponse) {
     }
 
     /*

--- a/live/administration/v1alpha1/workspace.proto
+++ b/live/administration/v1alpha1/workspace.proto
@@ -228,3 +228,19 @@ message GetDefaultWorkspaceResponse {
     */
     string workspace = 1;
 }
+
+message ResolveWorkspaceRequest {
+    /*
+    `Required`
+    The desired workspace name
+    */
+    string shortname = 1;
+}
+
+message ResolveWorkspaceResponse {
+    /*
+    `OutputOnly`
+    The name of the workspace best passed into the auth server
+    */
+    string workspace = 1;
+}

--- a/live/administration/v1alpha1/workspace.proto
+++ b/live/administration/v1alpha1/workspace.proto
@@ -170,3 +170,25 @@ message DeleteWorkspaceDeveloperResponse {
     */
     Workspace workspace = 1;
 }
+
+message SetDefaultWorkspaceRequest {
+    /*
+    `Required`
+    The id of the subscription for the workspace
+    */
+    string subscription = 1;
+
+    /*
+    The name of the workspace in the subscription
+    */
+    string workspace = 2;
+}
+
+message SetDefaultWorkspaceResponse {
+
+    /*
+    `OutputOnly`
+    The users default workspace
+    */
+    Workspace workspace = 1;
+}

--- a/live/administration/v1alpha1/workspace.proto
+++ b/live/administration/v1alpha1/workspace.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package ddev.administration.v1alpha1;
 
-option go_package = "github.com/drud/admin-api/gen/live/administration/v1alpha1";
+option go_package = "github.com/drud/ddev-apis-go/live/administration/v1alpha1";
 option java_multiple_files = true;
 option java_outer_classname = "ServiceProto";
 option java_package = "com.ddev.live.administration.v1alpha1";

--- a/live/administration/v1alpha1/workspace.proto
+++ b/live/administration/v1alpha1/workspace.proto
@@ -90,6 +90,12 @@ message AddWorkspaceAdminRequest {
     The email of the workspace administrator
     */
     string email = 2;
+
+    /*
+    `Required`
+    The subscription to which the workspace belongs
+    */
+    string subscription = 3;
 }
 
 message AddWorkspaceAdminResponse {
@@ -113,6 +119,12 @@ message AddWorkspaceDeveloperRequest {
     The email of the workspace developer.
     */
     string email = 2;
+
+    /*
+    `Required`
+    The subscription to which the workspace belongs
+    */
+    string subscription = 3;
 }
 
 message AddWorkspaceDeveloperResponse {
@@ -136,6 +148,12 @@ message DeleteWorkspaceAdminRequest {
     The email of the workspace administrator.
     */
     string email = 2;
+
+    /*
+    `Required`
+    The subscription to which the workspace belongs
+    */
+    string subscription = 3;
 }
 
 message DeleteWorkspaceAdminResponse {
@@ -160,6 +178,12 @@ message DeleteWorkspaceDeveloperRequest {
     The email of the workspace developer.
     */
     string email = 2;
+
+    /*
+    `Required`
+    The subscription to which the workspace belongs
+    */
+    string subscription = 3;
 }
 
 message DeleteWorkspaceDeveloperResponse {

--- a/live/administration/v1alpha1/workspace.proto
+++ b/live/administration/v1alpha1/workspace.proto
@@ -179,6 +179,7 @@ message SetDefaultWorkspaceRequest {
     string subscription = 1;
 
     /*
+    `Required`
     The name of the workspace in the subscription
     */
     string workspace = 2;

--- a/live/administration/v1alpha1/workspace.proto
+++ b/live/administration/v1alpha1/workspace.proto
@@ -50,6 +50,11 @@ message Workspace {
     The ID of the subscription which this workspace belongs
     */
     string subscription = 4;
+
+    /*
+    Optional metadata information about this workspace
+    */
+    map<string, string> metadata = 16;
 }
 
 
@@ -229,18 +234,18 @@ message GetDefaultWorkspaceResponse {
     string workspace = 1;
 }
 
-message ResolveWorkspaceRequest {
+message GetWorkspaceRequest {
     /*
     `Required`
     The desired workspace name
     */
-    string shortname = 1;
+    string name = 1;
 }
 
-message ResolveWorkspaceResponse {
+message GetWorkspaceResponse {
     /*
     `OutputOnly`
     The name of the workspace best passed into the auth server
     */
-    string workspace = 1;
+    Workspace workspace = 1;
 }

--- a/live/administration/v1alpha1/workspace.proto
+++ b/live/administration/v1alpha1/workspace.proto
@@ -217,3 +217,14 @@ message SetDefaultWorkspaceResponse {
     */
     Workspace workspace = 1;
 }
+
+message GetDefaultWorkspaceRequest {
+}
+
+message GetDefaultWorkspaceResponse {
+    /*
+    `OutputOnly`
+    The callers default workspace
+    */
+    string workspace = 1;
+}

--- a/live/sites/v1alpha1/BUILD.bazel
+++ b/live/sites/v1alpha1/BUILD.bazel
@@ -17,7 +17,7 @@ proto_library(
 go_proto_library(
     name = "v1alpha1_go_proto",
     compilers = ["@io_bazel_rules_go//proto:go_grpc"],
-    importpath = "github.com/drud/site-api/gen/live/sites/v1alpha1",
+    importpath = "github.com/drud/ddev-apis-go/live/sites/v1alpha1",
     proto = ":v1alpha1_proto",
     visibility = ["//visibility:public"],
 )
@@ -25,6 +25,6 @@ go_proto_library(
 go_library(
     name = "go_default_library",
     embed = [":v1alpha1_go_proto"],
-    importpath = "github.com/drud/site-api/gen/live/sites/v1alpha1",
+    importpath = "github.com/drud/ddev-apis-go/live/sites/v1alpha1",
     visibility = ["//visibility:public"],
 )

--- a/live/sites/v1alpha1/database.proto
+++ b/live/sites/v1alpha1/database.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package ddev.sites.v1alpha1;
 
-option go_package = "github.com/drud/site-api/gen/live/sites/v1alpha1";
+option go_package = "github.com/drud/ddev-apis-go/live/sites/v1alpha1";
 option java_multiple_files = true;
 option java_outer_classname = "DatabaseProto";
 option java_package = "com.ddev.live.sites.v1alpha1";

--- a/live/sites/v1alpha1/file.proto
+++ b/live/sites/v1alpha1/file.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package ddev.sites.v1alpha1;
 
-option go_package = "github.com/drud/site-api/gen/live/sites/v1alpha1";
+option go_package = "github.com/drud/ddev-apis-go/live/sites/v1alpha1";
 option java_multiple_files = true;
 option java_outer_classname = "FileProto";
 option java_package = "com.ddev.live.sites.v1alpha1";

--- a/live/sites/v1alpha1/metadata.proto
+++ b/live/sites/v1alpha1/metadata.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package ddev.sites.v1alpha1;
 
-option go_package = "github.com/drud/site-api/gen/live/sites/v1alpha1";
+option go_package = "github.com/drud/ddev-apis-go/live/sites/v1alpha1";
 option java_multiple_files = true;
 option java_outer_classname = "MetadataProto";
 option java_package = "com.ddev.live.sites.v1alpha1";

--- a/live/sites/v1alpha1/service.proto
+++ b/live/sites/v1alpha1/service.proto
@@ -20,7 +20,7 @@ import "live/sites/v1alpha1/database.proto";
 import "live/sites/v1alpha1/file.proto";
 import "live/sites/v1alpha1/site.proto";
 
-option go_package = "github.com/drud/site-api/gen/live/sites/v1alpha1";
+option go_package = "github.com/drud/ddev-apis-go/live/sites/v1alpha1";
 option java_multiple_files = true;
 option java_outer_classname = "ServiceProto";
 option java_package = "com.ddev.live.sites.v1alpha1";

--- a/live/sites/v1alpha1/site.proto
+++ b/live/sites/v1alpha1/site.proto
@@ -18,7 +18,7 @@ package ddev.sites.v1alpha1;
 
 import "live/sites/v1alpha1/metadata.proto";
 
-option go_package = "github.com/drud/site-api/gen/live/sites/v1alpha1";
+option go_package = "github.com/drud/ddev-apis-go/live/sites/v1alpha1";
 option java_multiple_files = true;
 option java_outer_classname = "SiteProto";
 option java_package = "com.ddev.live.sites.v1alpha1";


### PR DESCRIPTION
Currently a users default workspace is stored in a config element on their local machine.  This will push the default workspace up into remote state, allowing the authentication service to query a users default workspace if it has been set and allow internal services to set the default workspace for the first one provisioned by a registering user, removing the requirement that they authenticate with `--default-org` or know what the workspace even is if they provision only one.