### PR TITLE
[DEV-556] API call for exchange of workspace to k8s namespace

### DIFF
--- a/live/sites/v1alpha1/service.proto
+++ b/live/sites/v1alpha1/service.proto
@@ -227,4 +227,10 @@ service Sites {
     */
     rpc ListFileBackups(ListFileBackupsRequest) returns (ListFileBackupsResponse) {
     }
+
+    /*
+    NamespaceForWorkspace is a helper API call that allows exchange of a DDEV-Live workspace to Kubernetes namespace for legacy kubernetes API calls
+    */
+    rpc NamespaceForWorkspace(NamespaceForWorkspaceRequest) returns (NamespaceForWorkspaceResponse) {
+    }  
 }

--- a/live/sites/v1alpha1/site.proto
+++ b/live/sites/v1alpha1/site.proto
@@ -761,3 +761,19 @@ message SiteExecResponse {
   */
   bytes stderr = 2;
 }
+
+message NamespaceForWorkspaceRequest {
+  /*
+  `Required`
+  DDEV-Live workspace
+  */
+  string workspace = 1;
+}
+
+message NamespaceForWorkspaceResponse {
+  /*
+  `OutputOnly`
+  Kubernetes namespace
+  */
+  string namespace = 1;
+}


### PR DESCRIPTION
https://ddevhq.atlassian.net/browse/DEV-556
Introducing new API call where clients using legacy k8s API can exchange DDEV-Live workspace information and receive kubernetes namespace.